### PR TITLE
feat: added option to add header `Authorization` to the connect modal

### DIFF
--- a/src/components/ConnectionButton.tsx
+++ b/src/components/ConnectionButton.tsx
@@ -20,7 +20,7 @@ import { Label } from '@/components/ui/label';
 export const ConnectionButton: FC = () => {
   const [open, setOpen] = useState(false);
   const { toast } = useToast();
-  const { baseUrl, setBaseUrl, isConnected, authToken, setAuthToken, tryConnect} = useApi();
+  const { baseUrl, setBaseUrl, isConnected, authToken, setAuthToken, tryConnect } = useApi();
   const [url, setUrl] = useState(baseUrl);
   const [useAuthToken, setUseAuthToken] = useState(authToken !== '');
   const [userToken, setUserToken] = useState('');
@@ -52,7 +52,7 @@ export const ConnectionButton: FC = () => {
       return;
     }
     setUserToken(e.target.value);
-  }
+  };
 
   const handleConnect = async () => {
     try {
@@ -127,18 +127,18 @@ export const ConnectionButton: FC = () => {
               placeholder="http://127.0.0.1:5000"
             />
           </div>
-          
+
           <div className="flex items-center space-x-2">
-            <Checkbox 
-              id="use-auth" 
-              checked={useAuthToken} 
+            <Checkbox
+              id="use-auth"
+              checked={useAuthToken}
               onCheckedChange={(checked) => setUseAuthToken(checked === true)}
             />
-            <Label htmlFor="use-auth" className="text-sm font-medium cursor-pointer">
+            <Label htmlFor="use-auth" className="cursor-pointer text-sm font-medium">
               Add Authorization header
             </Label>
           </div>
-          
+
           {useAuthToken && (
             <div className="space-y-2">
               <label htmlFor="auth-token" className="text-sm font-medium">

--- a/src/components/ConnectionButton.tsx
+++ b/src/components/ConnectionButton.tsx
@@ -14,12 +14,16 @@ import { useToast } from '@/components/ui/use-toast';
 import { Network, Check, Copy } from 'lucide-react';
 import { useApi } from '@/contexts/ApiContext';
 import { cn } from '@/lib/utils';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
 
 export const ConnectionButton: FC = () => {
   const [open, setOpen] = useState(false);
   const { toast } = useToast();
-  const { baseUrl, setBaseUrl, isConnected } = useApi();
+  const { baseUrl, setBaseUrl, isConnected, authToken, setAuthToken, tryConnect} = useApi();
   const [url, setUrl] = useState(baseUrl);
+  const [useAuthToken, setUseAuthToken] = useState(authToken !== '');
+  const [userToken, setUserToken] = useState('');
 
   const features = [
     'Create new conversations',
@@ -37,9 +41,26 @@ export const ConnectionButton: FC = () => {
     });
   };
 
+  const onChangeUserToken = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value && e.target.value.startsWith('Bearer ')) {
+      setUserToken(e.target.value.replace('Bearer ', ''));
+      toast({
+        variant: 'default',
+        title: 'Formated token',
+        description: 'Detected "Bearer" prefix, it is now automatically removed',
+      });
+      return;
+    }
+    setUserToken(e.target.value);
+  }
+
   const handleConnect = async () => {
     try {
-      await setBaseUrl(url);
+      setBaseUrl(url);
+      if (useAuthToken) {
+        setAuthToken(userToken);
+      }
+      await tryConnect();
       toast({
         title: 'Connected',
         description: 'Successfully connected to gptme instance',
@@ -106,6 +127,34 @@ export const ConnectionButton: FC = () => {
               placeholder="http://127.0.0.1:5000"
             />
           </div>
+          
+          <div className="flex items-center space-x-2">
+            <Checkbox 
+              id="use-auth" 
+              checked={useAuthToken} 
+              onCheckedChange={(checked) => setUseAuthToken(checked === true)}
+            />
+            <Label htmlFor="use-auth" className="text-sm font-medium cursor-pointer">
+              Add Authorization header
+            </Label>
+          </div>
+          
+          {useAuthToken && (
+            <div className="space-y-2">
+              <label htmlFor="auth-token" className="text-sm font-medium">
+                User Token
+              </label>
+              <Input
+                id="auth-token"
+                value={userToken}
+                onChange={onChangeUserToken}
+                placeholder="Your authentication token"
+              />
+              <p className="text-xs text-muted-foreground">
+                Will be sent as: Authorization: Bearer "[user token]"
+              </p>
+            </div>
+          )}
 
           <div className="space-y-2">
             <label className="text-sm font-medium">Start the server with:</label>

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -1,13 +1,16 @@
-import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
-import { createApiClient } from '@/utils/api';
-import type { ApiClient } from '@/utils/api';
-import type { QueryClient } from '@tanstack/react-query';
+import type {ApiClient} from '@/utils/api';
+import {createApiClient} from '@/utils/api';
+import type {QueryClient} from '@tanstack/react-query';
+import {createContext, useContext, useEffect, useState, type ReactNode} from 'react';
 
 interface ApiContextType {
   api: ApiClient;
   isConnected: boolean;
   baseUrl: string;
   setBaseUrl: (url: string) => void;
+  authToken: string | null;
+  setAuthToken: (header: string | null) => void;
+  tryConnect: () => Promise<void>;
   // Add methods from ApiClient that are used in components
   getConversation: ApiClient['getConversation'];
   sendMessage: ApiClient['sendMessage'];
@@ -27,6 +30,7 @@ export function ApiProvider({
   queryClient: QueryClient;
 }) {
   const [baseUrl, setBaseUrl] = useState(initialBaseUrl);
+  const [authToken, setAuthToken] = useState<string | null>(null);
   const [api, setApi] = useState(() => createApiClient(initialBaseUrl));
   const [isConnected, setIsConnected] = useState(false);
 
@@ -53,32 +57,35 @@ export function ApiProvider({
   }, [api, baseUrl]);
 
   const updateBaseUrl = async (newUrl: string) => {
-    try {
       setBaseUrl(newUrl);
-      const newApi = createApiClient(newUrl);
+  };
 
-      // Update connection status
+  const updateAuthToken = (header: string | null) => {
+    setAuthToken(header);
+  };
+
+  const tryConnect = async () => {
+    try {
+      const newApi = createApiClient(baseUrl, `Bearer ${authToken}`);
       const connected = await newApi.checkConnection();
       if (!connected) {
         throw new Error('Failed to connect to API');
       }
-
       newApi.setConnected(true); // Explicitly set connection state
       setApi(newApi);
       setIsConnected(true);
-
-      // Invalidate and refetch all queries
       await queryClient.invalidateQueries();
       await queryClient.refetchQueries({
         queryKey: ['conversations'],
         type: 'active',
       });
     } catch (error) {
-      console.error('Failed to update API connection:', error);
+      console.error('Failed to connect to API:', error);
       setIsConnected(false);
-      throw error; // Re-throw to handle in the UI
+      throw error;
     }
-  };
+  }
+
 
   return (
     <ApiContext.Provider
@@ -87,6 +94,9 @@ export function ApiProvider({
         isConnected,
         baseUrl,
         setBaseUrl: updateBaseUrl,
+        authToken,
+        setAuthToken: updateAuthToken,
+        tryConnect,
         // Forward methods from the API client
         getConversation: api.getConversation.bind(api),
         sendMessage: api.sendMessage.bind(api),

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -1,7 +1,7 @@
-import type {ApiClient} from '@/utils/api';
-import {createApiClient} from '@/utils/api';
-import type {QueryClient} from '@tanstack/react-query';
-import {createContext, useContext, useEffect, useState, type ReactNode} from 'react';
+import type { ApiClient } from '@/utils/api';
+import { createApiClient } from '@/utils/api';
+import type { QueryClient } from '@tanstack/react-query';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 
 interface ApiContextType {
   api: ApiClient;
@@ -57,7 +57,7 @@ export function ApiProvider({
   }, [api, baseUrl]);
 
   const updateBaseUrl = async (newUrl: string) => {
-      setBaseUrl(newUrl);
+    setBaseUrl(newUrl);
   };
 
   const updateAuthToken = (header: string | null) => {
@@ -84,8 +84,7 @@ export function ApiProvider({
       setIsConnected(false);
       throw error;
     }
-  }
-
+  };
 
   return (
     <ApiContext.Provider

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,9 +1,9 @@
 import type {
-  ConversationResponse,
-  GenerateResponse,
   ApiError,
-  SendMessageRequest,
+  ConversationResponse,
   CreateConversationRequest,
+  GenerateResponse,
+  SendMessageRequest,
 } from '@/types/api';
 import type { Message } from '@/types/conversation';
 
@@ -43,7 +43,7 @@ export class ApiClient {
     this.baseUrl = baseUrl;
     this.authHeader = authHeader;
   }
-  
+
   private async fetchWithTimeout(
     url: string,
     options: RequestInit = {},
@@ -52,12 +52,15 @@ export class ApiClient {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
-    const headers = {
+    let headers = {
       ...options.headers,
     };
-    
+
     if (this.authHeader) {
-      headers['Authorization'] = this.authHeader;
+      headers = {
+        ...headers,
+        Authorization: this.authHeader,
+      };
     }
 
     try {
@@ -75,22 +78,23 @@ export class ApiClient {
   }
 
   private async fetchJson<T>(url: string, options: RequestInit = {}): Promise<T> {
-    const headers = {
-      'Content-Type': 'application/json',
+    let headers = {
       ...options.headers,
     };
-    
+
     if (this.authHeader) {
-      headers['Authorization'] = this.authHeader;
-    } else {
-      console.log('No Authorization header available for request');
+      headers = {
+        ...headers,
+        Authorization: this.authHeader,
+      };
     }
-    
-    console.log('Request headers:', headers);
-    
+
     const response = await fetch(url, {
       ...options,
-      headers,
+      headers: {
+        ...options.headers,
+        'Content-Type': 'applications/json',
+      },
     });
 
     if (!response.ok) {
@@ -267,15 +271,20 @@ export class ApiClient {
     let cleanup: (() => void) | undefined;
 
     try {
-      const headers = {
+      let headers: {
+        [key: string]: string;
+      } = {
         'Content-Type': 'application/json',
-        'Connection': 'keep-alive',
+        Connection: 'keep-alive',
       };
-      
+
       if (this.authHeader) {
-        headers['Authorization'] = this.authHeader;
+        headers = {
+          ...headers,
+          Authorization: this.authHeader,
+        };
       }
-      
+
       const response = await fetch(`${this.baseUrl}/api/conversations/${logfile}/generate`, {
         method: 'POST',
         headers,


### PR DESCRIPTION
disabled
![Screenshot from 2025-03-11 16-19-44](https://github.com/user-attachments/assets/08c801fe-17f6-47fb-a31f-e39a0673ba2f)
enabled
![Screenshot from 2025-03-11 16-20-02](https://github.com/user-attachments/assets/057347ec-506e-4359-a8a0-4c125e93c484)
When pasting value that starts with `Bearer ` => removes it and informs user with toast.
![Screenshot from 2025-03-11 16-20-19](https://github.com/user-attachments/assets/71cf50c3-a8fa-4fd3-9d4f-896eb2fd19f6)
