### PR TITLE
feat: support baseUrl and userToken via URL fragments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,23 @@ import { ApiProvider } from './contexts/ApiContext';
 import Index from './pages/Index';
 import type { FC } from 'react';
 
+// Parse URL fragment parameters
+const parseFragmentParams = () => {
+  const hash = window.location.hash.substring(1); // Remove the # character
+  const params = new URLSearchParams(hash);
+
+  const baseUrl = params.get('baseUrl');
+  const userToken = params.get('userToken');
+
+  // Clean up the URL by removing the fragment if we found parameters
+  if (baseUrl || userToken) {
+    // Remove the fragment from the URL to avoid exposing sensitive data
+    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+
+  return { baseUrl, userToken };
+};
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -31,10 +48,20 @@ const queryClient = new QueryClient({
 });
 
 const AppContent: FC = () => {
-  const apiUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:5000';
+  const defaultBaseUrl = import.meta.env.VITE_API_URL || 'http://127.0.0.1:5000';
+
+  // Parse fragment parameters synchronously before first render
+  const { baseUrl, userToken } = parseFragmentParams();
+
+  // Use the base URL from the fragment if available, otherwise use the default
+  const initialBaseUrl = baseUrl || defaultBaseUrl;
 
   return (
-    <ApiProvider initialBaseUrl={apiUrl} queryClient={queryClient}>
+    <ApiProvider
+      initialBaseUrl={initialBaseUrl}
+      initialAuthToken={userToken}
+      queryClient={queryClient}
+    >
       <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Index />
         <Toaster />

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -23,15 +23,19 @@ const ApiContext = createContext<ApiContextType | null>(null);
 export function ApiProvider({
   children,
   initialBaseUrl,
+  initialAuthToken = null,
   queryClient,
 }: {
   children: ReactNode;
   initialBaseUrl: string;
+  initialAuthToken?: string | null;
   queryClient: QueryClient;
 }) {
   const [baseUrl, setBaseUrl] = useState(initialBaseUrl);
-  const [authToken, setAuthToken] = useState<string | null>(null);
-  const [api, setApi] = useState(() => createApiClient(initialBaseUrl));
+  const [authToken, setAuthToken] = useState<string | null>(initialAuthToken);
+  const [api, setApi] = useState(() =>
+    createApiClient(initialBaseUrl, initialAuthToken ? `Bearer ${initialAuthToken}` : null)
+  );
   const [isConnected, setIsConnected] = useState(false);
 
   // Attempt initial connection


### PR DESCRIPTION
Fixes https://github.com/gptme/gptme-webui/issues/18

Example:

```
gptme-server --port 5001 --cors-origins '127.0.0.1:8080'
cd gptme-webui && npm run dev

# Then go to:
# http://localhost:8080/#baseUrl=http://127.0.0.1:5001&userToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `baseUrl` and `userToken` via URL fragments, enabling auto-connect to server in `App.tsx` and `ConnectionButton.tsx`.
> 
>   - **Behavior**:
>     - Support `baseUrl` and `userToken` via URL fragments in `App.tsx`.
>     - Auto-connect to server if `baseUrl` and `userToken` are provided in URL fragments in `ConnectionButton.tsx`.
>   - **Functions**:
>     - Add `parseFragmentParams()` in `App.tsx` to extract `baseUrl` and `userToken` from URL fragments.
>     - Modify `AppContent` in `App.tsx` to use parsed `baseUrl` and `userToken`.
>     - Update `ConnectionButton` to auto-connect using URL fragment parameters.
>   - **Context**:
>     - Update `ApiProvider` in `ApiContext.tsx` to accept `initialAuthToken` and manage connection state.
>     - Modify `tryConnect()` in `ApiContext.tsx` to handle new connection logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 2aaf4c6b5684db4389089671ff1e34be8693b86b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->