### PR TITLE
fix: fixes interruptions

### DIFF
--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -339,31 +339,6 @@ export function useConversation(conversation: ConversationItem): UseConversation
       // Always update local state
       setIsGenerating(false);
 
-      // Mark the conversation as interrupted in the UI
-      queryClient.setQueryData<ConversationResponse>(queryKey, (old) => {
-        if (!old?.log?.length) return old;
-
-        // Find the last assistant message
-        const messages = [...old.log];
-        for (let i = messages.length - 1; i >= 0; i--) {
-          if (messages[i].role === 'assistant') {
-            // Only add [interrupted] if it's not already there
-            if (!messages[i].content.includes('[interrupted]')) {
-              messages[i] = {
-                ...messages[i],
-                content: messages[i].content + '[interrupted]',
-              };
-            }
-            break;
-          }
-        }
-
-        return {
-          ...old,
-          log: messages,
-        };
-      });
-
       console.log('Generation interrupted successfully');
     } catch (error) {
       console.error('Error in interrupt handler:', error);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -201,6 +201,7 @@ export class ApiClient {
       onMessageComplete: (message: Message) => void;
       onMessageAdded: (message: Message) => void;
       onToolPending: (toolId: string, tooluse: ToolUse, auto_confirm: boolean) => void;
+      onInterrupted: () => void;
       onError: (error: string) => void;
     }
   ): void {
@@ -287,6 +288,10 @@ export class ApiClient {
           case 'connected':
             console.log(`[ApiClient] Session connected event:`, data);
             this.sessions.set(conversationId, data.session_id);
+            break;
+
+          case 'interrupted':
+            callbacks.onInterrupted();
             break;
 
           default:


### PR DESCRIPTION
Needs https://github.com/gptme/gptme/commit/adad11446e7e20dc100b61b66465d1915f1a0115
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds interruption handling in `useConversation.ts` and `ApiClient` to manage UI state and pending tools on generation interruption.
> 
>   - **Behavior**:
>     - Adds `onInterrupted` callback in `ApiClient` to handle interruption events.
>     - In `useConversation.ts`, adds `onInterrupted` handler to clear generating state and pending tools, and mark conversation as interrupted in the UI.
>   - **Code Cleanup**:
>     - Removes redundant interruption handling logic from `useConversation.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for abdfb5e4319a924e497612cb410c634b0a4bdd82. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->