### PR TITLE
fix: support non-streaming LLM requests

### DIFF
--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -451,7 +451,7 @@ export function useConversation(conversation: ConversationItem): UseConversation
 
         // Initial generation
         console.log('[useConversation] Starting generation');
-        await api.step(conversation.name, options?.model);
+        await api.step(conversation.name, options?.model, options?.stream);
 
         console.log('[useConversation] Generation started, waiting for events');
       } catch (error) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -444,7 +444,12 @@ export class ApiClient {
     }
   }
 
-  async step(logfile: string, model?: string, branch: string = 'main'): Promise<void> {
+  async step(
+    logfile: string,
+    model?: string,
+    stream: boolean = true,
+    branch: string = 'main'
+  ): Promise<void> {
     if (!this._isConnected) {
       throw new Error('Not connected to API');
     }
@@ -482,7 +487,7 @@ export class ApiClient {
         {
           method: 'POST',
           headers,
-          body: JSON.stringify({ session_id: sessionId, model, branch }),
+          body: JSON.stringify({ session_id: sessionId, model, branch, stream }),
           signal: this.controller.signal,
         }
       );


### PR DESCRIPTION
Requires https://github.com/gptme/gptme/pull/481
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for non-streaming LLM requests by introducing a `stream` parameter to `api.step()` in `useConversation.ts` and `ApiClient`.
> 
>   - **Behavior**:
>     - Adds `stream` parameter to `api.step()` in `useConversation.ts` to support non-streaming requests.
>     - Updates `step()` in `ApiClient` to accept `stream` parameter, defaulting to `true`.
>   - **Functions**:
>     - Modifies `step()` in `api.ts` to include `stream` in the request body.
>     - Updates `useConversation()` in `useConversation.ts` to pass `stream` option to `api.step()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 071c86b73acd661c76b49af4f33eebf2dd0439b5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->