### PR TITLE
fix: chatmessage styling not updating on new messages

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -122,8 +122,7 @@ export const ChatMessage: FC<Props> = ({
   );
 
   const chainType$ = useMessageChainType(message$, previousMessage$, nextMessage$);
-
-  const messageClasses = useObservable(
+  const messageClasses$ = useObservable(
     () => `
         ${
           isUser$.get()
@@ -147,8 +146,7 @@ export const ChatMessage: FC<Props> = ({
         border
     `
   );
-
-  const wrapperClasses = useObservable(
+  const wrapperClasses$ = useObservable(
     () => `
         ${chainType$.get() !== 'start' && chainType$.get() !== 'standalone' ? '-mt-[2px]' : 'mt-4'}
         ${chainType$.get() === 'standalone' ? 'mb-4' : 'mb-0'}
@@ -156,32 +154,38 @@ export const ChatMessage: FC<Props> = ({
   );
 
   return (
-    <div className={`role-${message$.role.get()} ${wrapperClasses.get()}`}>
-      <div className="mx-auto max-w-3xl px-4">
-        <div className="relative">
-          <MessageAvatar
-            role$={message$.role}
-            isError$={isError$}
-            isSuccess$={isSuccess$}
-            chainType$={chainType$}
-          />
-          <div className="md:px-12">
-            <div className={messageClasses.get()}>
-              <div className="px-3 py-1.5">
-                <Memo>
-                  {() => (
-                    <div
-                      className="chat-message prose prose-sm dark:prose-invert prose-pre:overflow-x-auto prose-pre:max-w-[calc(100vw-16rem)]"
-                      dangerouslySetInnerHTML={{ __html: processedContent$.get() }}
-                    />
-                  )}
-                </Memo>
-                {renderFiles()}
+    <Memo>
+      {() => {
+        return (
+          <div className={`role-${message$.role.get()} ${wrapperClasses$.get()}`}>
+            <div className="mx-auto max-w-3xl px-4">
+              <div className="relative">
+                <MessageAvatar
+                  role$={message$.role}
+                  isError$={isError$}
+                  isSuccess$={isSuccess$}
+                  chainType$={chainType$}
+                />
+                <div className="md:px-12">
+                  <div className={messageClasses$.get()}>
+                    <div className="px-3 py-1.5">
+                      <Memo>
+                        {() => (
+                          <div
+                            className="chat-message prose prose-sm dark:prose-invert prose-pre:overflow-x-auto prose-pre:max-w-[calc(100vw-16rem)]"
+                            dangerouslySetInnerHTML={{ __html: processedContent$.get() }}
+                          />
+                        )}
+                      </Memo>
+                      {renderFiles()}
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </div>
-    </div>
+        );
+      }}
+    </Memo>
   );
 };

--- a/src/components/ConversationContent.tsx
+++ b/src/components/ConversationContent.tsx
@@ -172,10 +172,7 @@ export const ConversationContent: FC<Props> = ({ conversation }) => {
 
               // Get the previous and next messages for spacing context
               const previousMessage$ = index > 0 ? conversationData$.log[index - 1] : undefined;
-              const nextMessage$ =
-                index < conversationData$.log.length - 1
-                  ? conversationData$.log[index + 1]
-                  : undefined;
+              const nextMessage$ = conversationData$.log[index + 1];
 
               return (
                 <ChatMessage

--- a/src/utils/messageUtils.ts
+++ b/src/utils/messageUtils.ts
@@ -10,9 +10,13 @@ export const useMessageChainType = (
   nextMessage$: Observable<Message | undefined> | undefined
 ) => {
   const messageChainType$ = useObservable(() => {
-    const isChainStart = !previousMessage$ || previousMessage$.role.get() === 'user';
-    const isChainEnd = !nextMessage$ || nextMessage$.role.get() === 'user';
-    const isPartOfChain = isNonUserMessage(message$.role.get());
+    const message = message$.get();
+    const previousMessage = previousMessage$?.get();
+    const nextMessage = nextMessage$?.get();
+
+    const isChainStart = !previousMessage || previousMessage.role === 'user';
+    const isChainEnd = !nextMessage || nextMessage.role === 'user';
+    const isPartOfChain = isNonUserMessage(message.role);
 
     if (!isPartOfChain) return 'standalone';
     if (isChainStart && isChainEnd) return 'standalone';


### PR DESCRIPTION
Fixes one issue in #28 (Fix bug introduced in https://github.com/gptme/gptme-webui/pull/26 where messages are no longer correctly chained for streamed messages (margin between messages, rounding is wrong)).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes chat message styling by correcting message chaining logic and updating observables in `ChatMessage.tsx` and `ConversationContent.tsx`.
> 
>   - **Behavior**:
>     - Fixes message chaining logic in `useMessageChainType()` in `messageUtils.ts` to correctly identify start, middle, end, and standalone messages.
>     - Updates `ConversationContent.tsx` to always define `nextMessage$` for correct spacing context.
>   - **Components**:
>     - Renames `messageClasses` to `messageClasses$` and `wrapperClasses` to `wrapperClasses$` in `ChatMessage.tsx` to reflect observable nature.
>     - Wraps the return JSX in `ChatMessage.tsx` with `Memo` for performance optimization.
>   - **Misc**:
>     - Minor refactoring in `ChatMessage.tsx` to improve readability and maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 7f0fe605ac24671ffdc042f7b352576de7aee755. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->