### PR TITLE
feat: add button to view rendered markdown blocks

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -30,7 +30,7 @@ export const ChatMessage: FC<Props> = ({
   // Initialize the renderer and parser once the contentRef is available
   useEffect(() => {
     if (!contentRef.current) return;
-    const renderer = customRenderer(contentRef.current);
+    const renderer = customRenderer(contentRef.current, false, true);
     renderer$.set(ObservableHint.opaque(renderer));
     const parser = smd.parser(renderer);
     parser$.set(ObservableHint.opaque(parser));

--- a/src/components/CodeDisplay.tsx
+++ b/src/components/CodeDisplay.tsx
@@ -25,7 +25,7 @@ export function CodeDisplay({
     if (!code) return;
 
     // Use our shared utility
-    setHighlightedCode(highlightCode(code, language, true, 1000));
+    setHighlightedCode(highlightCode(code, language, true, 1000).code);
   }, [code, language]);
 
   if (!code) return null;

--- a/src/components/TabbedCodeBlock.tsx
+++ b/src/components/TabbedCodeBlock.tsx
@@ -1,0 +1,109 @@
+import { useState, useRef, useEffect } from 'react';
+import { getCodeBlockEmoji } from '@/utils/markdownUtils';
+import * as smd from '@/utils/smd';
+import { customRenderer } from '@/utils/markdownRenderer';
+
+/**
+ * Props for the TabbedCodeBlock component
+ */
+interface TabbedCodeBlockProps {
+  /** The language or file extension of the code */
+  language?: string;
+  /** The raw code content to display */
+  codeText: string;
+  /** The code element to display */
+  code: HTMLElement;
+}
+
+/**
+ * TabbedCodeBlock renders a code block with tabs for switching between
+ * code view and preview. Preview is only available for markdown and HTML content.
+ *
+ * For markdown content, it uses the streaming markdown parser to render the preview.
+ * For HTML content, it directly sets the innerHTML.
+ */
+export const TabbedCodeBlock: React.FC<TabbedCodeBlockProps> = ({ language, codeText, code }) => {
+  const [activeTab, setActiveTab] = useState<'code' | 'preview'>('code');
+  const previewRef = useRef<HTMLDivElement>(null);
+  const [renderError, setRenderError] = useState<string | null>(null);
+
+  const emoji = getCodeBlockEmoji(language || '');
+
+  // Check if this is a markdown code block
+  const isMarkdown = language === 'md' || language === 'markdown';
+
+  // Determine if preview should be available - only for markdown or HTML
+  const hasPreview = isMarkdown || language === 'html';
+
+  // Handle markdown rendering when the preview tab is selected
+  useEffect(() => {
+    if (previewRef.current && codeText) {
+      try {
+        // Clear previous content and error state
+        previewRef.current.innerHTML = '';
+        setRenderError(null);
+
+        if (isMarkdown) {
+          // Use streaming markdown parser for markdown content
+          const renderer = customRenderer(previewRef.current);
+          const parser = smd.parser(renderer);
+          smd.parser_write(parser, codeText);
+          smd.parser_end(parser);
+        } else if (language === 'html') {
+          // For HTML content, just set the innerHTML
+          previewRef.current.innerHTML = codeText;
+        }
+      } catch (error) {
+        console.error('Error rendering preview:', error);
+        setRenderError('Failed to render preview');
+      }
+    }
+  }, [codeText, language, isMarkdown]);
+
+  return (
+    <div>
+      <div className="flex bg-gray-50 !p-0 dark:bg-gray-900">
+        <button
+          className={`px-4 py-2 text-xs font-normal transition-colors ${
+            activeTab === 'code'
+              ? 'border-b-2 border-blue-500 bg-white dark:bg-gray-800'
+              : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+          }`}
+          onClick={() => setActiveTab('code')}
+        >
+          {emoji} Code
+        </button>
+        {hasPreview && (
+          <button
+            className={`px-4 py-2 text-xs font-normal transition-colors ${
+              activeTab === 'preview'
+                ? 'border-b-2 border-blue-500 bg-white dark:bg-gray-800'
+                : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+            }`}
+            onClick={() => setActiveTab('preview')}
+          >
+            👁️ Preview
+          </button>
+        )}
+      </div>
+
+      <div className="overflow-auto">
+        <pre
+          className={`m-0 overflow-auto ${activeTab === 'preview' ? '!hidden' : ''}`}
+          dangerouslySetInnerHTML={{ __html: code.outerHTML }}
+        />
+        {renderError && activeTab === 'preview' && (
+          <div className="rounded-md bg-red-50 p-4 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+            {renderError}
+          </div>
+        )}
+        <div
+          ref={previewRef}
+          className={`preview-content prose prose-sm dark:prose-invert mx-4 !mt-[-10px] mb-4 max-w-none ${
+            activeTab === 'code' && !renderError ? '!hidden' : ''
+          }`}
+        ></div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TabbedCodeBlock.tsx
+++ b/src/components/TabbedCodeBlock.tsx
@@ -30,10 +30,10 @@ export const TabbedCodeBlock: React.FC<TabbedCodeBlockProps> = ({ language, code
   const emoji = getCodeBlockEmoji(language || '');
 
   // Check if this is a markdown code block
-  const isMarkdown = language === 'md' || language === 'markdown';
+  const isMarkdown = language?.toLowerCase() === 'md' || language?.toLowerCase() === 'markdown';
 
   // Determine if preview should be available - only for markdown or HTML
-  const hasPreview = isMarkdown || language === 'html';
+  const hasPreview = isMarkdown || language?.toLowerCase() === 'html';
 
   // Handle markdown rendering when the preview tab is selected
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -140,7 +140,7 @@
 }
 
 .chat-message details {
-  @apply my-2 overflow-hidden rounded-md border border-border text-sm dark:border-stone-950;
+  @apply my-2 overflow-hidden rounded-md border border-border bg-white font-sans text-sm dark:border-stone-950 dark:bg-slate-900;
 }
 
 .chat-message details summary {

--- a/src/utils/__tests__/markdownRenderer.test.ts
+++ b/src/utils/__tests__/markdownRenderer.test.ts
@@ -1,0 +1,167 @@
+import '@testing-library/jest-dom';
+import { customRenderer } from '../markdownRenderer';
+import * as smd from '@/utils/smd';
+
+function parse(markdown: string, streaming: boolean = false, log: boolean = false) {
+  const div = document.createElement('div');
+  const renderer = customRenderer(div, log);
+  const parser = smd.parser(renderer);
+
+  if (streaming) {
+    for (const char of markdown) {
+      smd.parser_write(parser, char);
+    }
+  } else {
+    smd.parser_write(parser, markdown);
+  }
+
+  smd.parser_end(parser);
+  return div;
+}
+
+describe('simple text rendering', () => {
+  const markdown = 'This is a test';
+  it('all at once, should render standard text', () => {
+    const div = parse(markdown);
+
+    // Output should be:
+    // <div>
+    //   <p>
+    //     This is a test
+    //   </p>
+    // </div>
+    expect(div.innerHTML).toBe('<p>This is a test</p>');
+  });
+
+  it('should render standard text, one character at a time', () => {
+    const div = parse(markdown, true);
+
+    // Output should be:
+    // <div>
+    //   <p>
+    //     This is a test
+    //   </p>
+    // </div>
+    expect(div.innerHTML).toBe('<p>This is a test</p>');
+  });
+});
+
+describe('renderThinkingBlocks', () => {
+  it('should handle one thinking block at start of text', () => {
+    const markdown = `<thinking>This is a thinking block</thinking> some other text`;
+
+    // Output should be:
+    // <div>
+    //   <p>
+    //     <details type="thinking" open="true">
+    //       <summary>💭 Thinking</summary>
+    //       <div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div>
+    //     </details>
+    //     some other text
+    //   </p>
+    // </div>
+    const expected =
+      '<p><details type="thinking" open="true"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details> some other text</p>';
+
+    let div = parse(markdown);
+    expect(div.innerHTML).toBe(expected);
+
+    div = parse(markdown, true);
+    expect(div.innerHTML).toBe(expected);
+  });
+
+  it('should handle one thinking block at end of text', () => {
+    const markdown = `some other text <thinking>This is a thinking block</thinking>`;
+
+    // Output should be:
+    // <div>
+    //   <p>
+    //     some other text
+    //     <details type="thinking" open="true">
+    //       <summary>💭 Thinking</summary>
+    //       <div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div>
+    //     </details>
+    //   </p>
+    // </div>
+    const expected =
+      '<p>some other text <details type="thinking" open="true"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details></p>';
+
+    let div = parse(markdown);
+    expect(div.innerHTML).toBe(expected);
+
+    div = parse(markdown, true);
+    expect(div.innerHTML).toBe(expected);
+  });
+
+  it('should handle multiple thinking blocks', () => {
+    const markdown = `some other text <thinking>This is a thinking block</thinking> some other text <thinking>This is another thinking block</thinking>`;
+
+    // Output should be:
+    // <div>
+    //   <p>
+    //     some other text
+    //     <details type="thinking" open="true">
+    //       <summary>💭 Thinking</summary>
+    //       <div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div>
+    //     </details>
+    //     some other text
+    //     <details type="thinking" open="true">
+    //       <summary>💭 Thinking</summary>
+    //       <div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is another thinking block</div>
+    //     </details>
+    //   </p>
+    // </div>
+    const expected =
+      '<p>some other text <details type="thinking" open="true"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details> some other text <details type="thinking" open="true"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is another thinking block</div></details></p>';
+
+    const div = parse(markdown);
+    expect(div.innerHTML).toBe(expected);
+
+    const div2 = parse(markdown, true);
+    expect(div2.innerHTML).toBe(expected);
+  });
+});
+
+describe('renderCodeBlocks', () => {
+  it('should handle one python code block at start of text', () => {
+    const markdown = `\`\`\`python\nThis is a code block\n\`\`\` some other text`;
+
+    const expected =
+      '<details open="true"><summary>💻 python</summary><pre><code class="hljs language-python">This <span class="hljs-keyword">is</span> a code block</code></pre></details><p>some other text</p>';
+
+    let div = parse(markdown);
+    expect(div.innerHTML).toBe(expected);
+
+    div = parse(markdown, true);
+    expect(div.innerHTML).toBe(expected);
+  });
+
+  it('should handle one python code block at end of text', () => {
+    const markdown = `some other text\n\`\`\`python\nThis is a code block\n\`\`\``;
+
+    const expected =
+      '<p>some other text<details open="true"><summary>💻 python</summary><pre><code class="hljs language-python">This <span class="hljs-keyword">is</span> a code block</code></pre></details></p>';
+
+    let div = parse(markdown);
+    expect(div.innerHTML).toBe(expected);
+
+    div = parse(markdown, true);
+    expect(div.innerHTML).toBe(expected);
+  });
+});
+
+describe('renderMarkdownBlocks', () => {
+  it('should handle one markdown block at start of text', () => {
+    const markdown = `\`\`\`markdown\nThis is a markdown block\n\`\`\`\nsome other text`;
+
+    const expected =
+      '<details open="true"><summary>💻 markdown</summary><pre><code class="hljs language-markdown">This is a markdown block</code></pre></details><p>some other text</p>';
+
+    let div = parse(markdown, false, true);
+    console.log(div.innerHTML);
+    expect(div.innerHTML).toBe(expected);
+
+    div = parse(markdown, true, false);
+    expect(div.innerHTML).toBe(expected);
+  });
+});

--- a/src/utils/highlightUtils.ts
+++ b/src/utils/highlightUtils.ts
@@ -1,21 +1,28 @@
 import hljs from 'highlight.js';
 //import 'highlight.js/styles/github-dark.css';
 
+export interface HighlightResult {
+  // The highlighted code
+  code: string;
+  // The detected language of the code
+  language?: string;
+}
+
 /**
  * Highlight code with syntax highlighting
  * @param code The code to highlight
  * @param language Optional language specification
  * @param autoDetect Whether to attempt language auto-detection if language not specified
  * @param maxDetectionLength Maximum length for auto-detection (for performance)
- * @returns HTML string with highlighted code
+ * @returns HighlightResult object with highlighted code and language
  */
 export function highlightCode(
   code: string,
   language?: string,
   autoDetect = true,
-  maxDetectionLength = 1000
-): string {
-  if (!code) return '';
+  maxDetectionLength = 10000
+): HighlightResult {
+  if (!code) return { code: '' };
 
   try {
     // Normalize language name
@@ -26,21 +33,22 @@ export function highlightCode(
 
       // Check if language is supported
       if (hljs.getLanguage(language)) {
-        return hljs.highlight(code, { language }).value;
+        return { code: hljs.highlight(code, { language }).value, language };
       }
     }
 
     // Auto-detect language for shorter code blocks if requested
     if (autoDetect && code.length < maxDetectionLength) {
-      return hljs.highlightAuto(code).value;
+      const result = hljs.highlightAuto(code);
+      return { code: result.value, language: result.language };
     }
 
     // Return escaped plain text for larger blocks or when auto-detect is disabled
-    return code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return { code: code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') };
   } catch (error) {
     console.warn('Syntax highlighting error:', error);
     // Return escaped text on error
-    return code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return { code: code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') };
   }
 }
 

--- a/src/utils/markdownRenderer.ts
+++ b/src/utils/markdownRenderer.ts
@@ -1,13 +1,26 @@
 import { getCodeBlockEmoji } from '@/utils/markdownUtils';
 import * as smd from '@/utils/smd';
 import { highlightCode } from '@/utils/highlightUtils';
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { TabbedCodeBlock } from '@/components/TabbedCodeBlock';
 
+/**
+ * CustomRendererData extends the default renderer data with additional properties
+ * for tracking code blocks, their language, and content.
+ */
 export type CustomRendererData = smd.Default_Renderer_Data & {
+  placeholder: HTMLElement | null;
   summary: HTMLElement | null;
   code: HTMLElement | null;
   lang: string | null;
+  codeText: string; // Store code text for preview
 };
 
+/**
+ * CustomRenderer type extends the default renderer with our own implementation
+ * of the render methods.
+ */
 export type CustomRenderer = Omit<
   smd.Default_Renderer,
   'add_token' | 'end_token' | 'set_attr' | 'add_text'
@@ -19,9 +32,25 @@ export type CustomRenderer = Omit<
   data: CustomRendererData;
 };
 
-export function customRenderer(root: HTMLElement): CustomRenderer {
+/**
+ * Creates a custom renderer for streaming markdown that can optionally render
+ * code blocks as React components with tabs for viewing code and its preview.
+ *
+ * @param root - The HTML element to render content into
+ * @param log - Whether to log rendering details (for debugging)
+ * @param useReactTabbed - Whether to use React components for code blocks with tabs
+ * @returns A CustomRenderer instance
+ */
+export function customRenderer(
+  root: HTMLElement,
+  log: boolean = false,
+  useReactTabbed: boolean = false
+): CustomRenderer {
   return {
     add_token: (data: CustomRendererData, type: smd.Token) => {
+      if (log) {
+        console.log('add_token:', smd.token_to_string(type));
+      }
       let parent = data.nodes[data.index];
       let slot;
 
@@ -32,39 +61,95 @@ export function customRenderer(root: HTMLElement): CustomRenderer {
           parent.setAttribute('open', 'true');
           data.summary = parent.appendChild(document.createElement('summary'));
           data.summary.textContent = '💻 Code';
+
+          if (useReactTabbed) {
+            // Create placeholder element to be replaced with React component later
+            const placeholderDiv = document.createElement('div');
+            placeholderDiv.className = 'tabbed-code-block-placeholder !p-0';
+            data.placeholder = placeholderDiv;
+            data.codeText = ''; // Initialize codeText for this block
+            parent = parent.appendChild(placeholderDiv);
+          }
+
           parent = parent.appendChild(document.createElement('pre'));
           slot = document.createElement('code');
           data.code = slot;
           slot.setAttribute('class', 'hljs');
+          data.nodes[++data.index] = parent.appendChild(slot);
+          // }
           break;
         }
         default:
           smd.default_add_token(data, type);
           return;
       }
-      data.nodes[++data.index] = parent.appendChild(slot);
     },
     end_token: (data: CustomRendererData) => {
+      if (log) {
+        console.log('end_token');
+      }
+
+      if (useReactTabbed && data.placeholder && data.code && data.lang && data.codeText) {
+        const langFromInfo = data.lang ? data.lang.split('.').pop() : undefined;
+        if (langFromInfo !== 'md' && langFromInfo !== 'markdown') return;
+        try {
+          // Create React root and render the component
+          const reactRoot = createRoot(data.placeholder);
+          reactRoot.render(
+            createElement(TabbedCodeBlock, {
+              language: langFromInfo,
+              codeText: data.codeText,
+              code: data.code!,
+            })
+          );
+        } catch (error) {
+          console.error('Error rendering TabbedCodeBlock:', error);
+        }
+      }
+
       data.summary = null;
       data.lang = null;
       data.code = null;
+      data.codeText = '';
       smd.default_end_token(data);
     },
     add_text: (data: CustomRendererData, text: string) => {
-      // Highlight code blocks
-      if (data.lang) {
+      if (log) {
+        console.log('add_text:', text);
+      }
+
+      if (data.code) {
+        // Highlight code blocks
+        const lang = data.lang;
+        const langFromInfo = lang ? lang.split('.').pop() : undefined;
         const previousText = data.nodes[data.index].textContent;
         const newText = previousText + text;
-        const langFromInfo = data.lang ? data.lang.split('.').pop() : undefined;
         const highlighted = highlightCode(newText, langFromInfo, true);
-        data.nodes[data.index].innerHTML = highlighted;
+        // Update the language if it was detected
+        if (highlighted.language) {
+          data.lang = highlighted.language;
+        }
+        data.nodes[data.index].innerHTML = highlighted.code;
+
+        const isMarkdown = highlighted.language === 'md' || highlighted.language === 'markdown';
+        // Store code text for React tabbed component
+        if (useReactTabbed && data.placeholder && isMarkdown) {
+          data.codeText += text;
+        } else {
+          data.placeholder = null;
+        }
       } else {
         smd.default_add_text(data, text);
       }
     },
     set_attr: (data: CustomRendererData, type: smd.Attr, value: string) => {
+      if (log) {
+        console.log('set_attr:', smd.attr_to_html_attr(type), value);
+      }
+
       // Set the language in the summary tag
       if (type === smd.LANG) {
+        data.lang = value;
         if (data.summary) {
           const emoji = getCodeBlockEmoji(value);
           data.summary.textContent = `${emoji} ${value}`;
@@ -73,7 +158,6 @@ export function customRenderer(root: HTMLElement): CustomRenderer {
           const langFromInfo = value ? value.split('.').pop() : undefined;
           data.code.setAttribute('class', `hljs ${langFromInfo ? `language-${langFromInfo}` : ''}`);
         }
-        data.lang = value;
       } else {
         smd.default_set_attr(data, type, value);
       }
@@ -81,9 +165,11 @@ export function customRenderer(root: HTMLElement): CustomRenderer {
     data: {
       nodes: [root],
       index: 0,
+      placeholder: null,
       summary: null,
       lang: null,
       code: null,
+      codeText: '',
     },
   };
 }

--- a/src/utils/markdownRenderer.ts
+++ b/src/utils/markdownRenderer.ts
@@ -91,6 +91,7 @@ export function customRenderer(
 
       if (useReactTabbed && data.placeholder && data.code && data.lang && data.codeText) {
         const langFromInfo = data.lang ? data.lang.split('.').pop() : undefined;
+        // Only render for markdown and html
         if (langFromInfo !== 'md' && langFromInfo !== 'markdown' && langFromInfo !== 'html') return;
         try {
           // Create React root and render the component
@@ -131,12 +132,12 @@ export function customRenderer(
         }
         data.nodes[data.index].innerHTML = highlighted.code;
 
-        const isMarkdown =
+        const isMarkdownOrHtml =
           highlighted.language === 'md' ||
           highlighted.language === 'markdown' ||
           highlighted.language === 'html';
         // Store code text for React tabbed component
-        if (useReactTabbed && data.placeholder && isMarkdown) {
+        if (useReactTabbed && data.placeholder && isMarkdownOrHtml) {
           data.codeText += text;
         } else {
           data.placeholder = null;

--- a/src/utils/markdownRenderer.ts
+++ b/src/utils/markdownRenderer.ts
@@ -91,7 +91,7 @@ export function customRenderer(
 
       if (useReactTabbed && data.placeholder && data.code && data.lang && data.codeText) {
         const langFromInfo = data.lang ? data.lang.split('.').pop() : undefined;
-        if (langFromInfo !== 'md' && langFromInfo !== 'markdown') return;
+        if (langFromInfo !== 'md' && langFromInfo !== 'markdown' && langFromInfo !== 'html') return;
         try {
           // Create React root and render the component
           const reactRoot = createRoot(data.placeholder);
@@ -131,7 +131,10 @@ export function customRenderer(
         }
         data.nodes[data.index].innerHTML = highlighted.code;
 
-        const isMarkdown = highlighted.language === 'md' || highlighted.language === 'markdown';
+        const isMarkdown =
+          highlighted.language === 'md' ||
+          highlighted.language === 'markdown' ||
+          highlighted.language === 'html';
         // Store code text for React tabbed component
         if (useReactTabbed && data.placeholder && isMarkdown) {
           data.codeText += text;

--- a/src/utils/markdownRenderer.ts
+++ b/src/utils/markdownRenderer.ts
@@ -6,6 +6,19 @@ import { createRoot } from 'react-dom/client';
 import { TabbedCodeBlock } from '@/components/TabbedCodeBlock';
 
 /**
+ * Checks if the language is markdown or html
+ * @param language - The language of the code block
+ * @returns True if the language is markdown or html, false otherwise
+ */
+function isMarkdownOrHtml(language: string | null | undefined): boolean {
+  return (
+    language?.toLowerCase() === 'md' ||
+    language?.toLowerCase() === 'markdown' ||
+    language?.toLowerCase() === 'html'
+  );
+}
+
+/**
  * CustomRendererData extends the default renderer data with additional properties
  * for tracking code blocks, their language, and content.
  */
@@ -92,7 +105,7 @@ export function customRenderer(
       if (useReactTabbed && data.placeholder && data.code && data.lang && data.codeText) {
         const langFromInfo = data.lang ? data.lang.split('.').pop() : undefined;
         // Only render for markdown and html
-        if (langFromInfo !== 'md' && langFromInfo !== 'markdown' && langFromInfo !== 'html') return;
+        if (!isMarkdownOrHtml(langFromInfo)) return;
         try {
           // Create React root and render the component
           const reactRoot = createRoot(data.placeholder);
@@ -132,12 +145,8 @@ export function customRenderer(
         }
         data.nodes[data.index].innerHTML = highlighted.code;
 
-        const isMarkdownOrHtml =
-          highlighted.language === 'md' ||
-          highlighted.language === 'markdown' ||
-          highlighted.language === 'html';
         // Store code text for React tabbed component
-        if (useReactTabbed && data.placeholder && isMarkdownOrHtml) {
+        if (useReactTabbed && data.placeholder && isMarkdownOrHtml(highlighted.language)) {
           data.codeText += text;
         } else {
           data.placeholder = null;

--- a/src/utils/markdownUtils.ts
+++ b/src/utils/markdownUtils.ts
@@ -33,7 +33,7 @@ marked.use(
       // Use info for file extension detection if available
       const langFromInfo = info ? info.split('.').pop() : undefined;
       // Use our shared utility
-      return highlightCode(code, langFromInfo || lang, true);
+      return highlightCode(code, langFromInfo || lang, true).code;
     },
   })
 );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add tabbed interface for rendering markdown code blocks with code and preview views.
> 
>   - **Components**:
>     - Add `TabbedCodeBlock` component to render code blocks with tabs for code and preview views.
>     - Update `ChatMessage.tsx` to use `customRenderer` with `useReactTabbed` option.
>     - Modify `CodeDisplay.tsx` to use updated `highlightCode` function.
>   - **Utilities**:
>     - Update `highlightCode` in `highlightUtils.ts` to return `HighlightResult` object with `code` and `language`.
>     - Modify `customRenderer` in `markdownRenderer.ts` to support tabbed code blocks using React components.
>   - **Styles**:
>     - Update `index.css` to style tabbed code blocks and previews.
>   - **Tests**:
>     - Add `markdownRenderer.test.ts` to test rendering of markdown and code blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 8f00fe13094014c5a910d23899bc19d7acfe27d8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->