### PR TITLE
feat: retry getting session id if not received

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -102,6 +102,7 @@ export const ChatInput: FC<Props> = ({
       handleSubmit(e);
     } else if (e.key === 'Escape' && isGenerating$.get() && onInterrupt) {
       e.preventDefault();
+      e.stopPropagation(); // Prevent bubbling up to the global keyboard shortcut
       console.log('[ChatInput] Escape pressed, interrupting generation...');
       onInterrupt();
     }

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -14,7 +14,7 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { type Observable } from '@legendapp/state';
-import { Computed, use$, useObserveEffect } from '@legendapp/state/react';
+import { Computed, useObservable, use$ } from '@legendapp/state/react';
 
 export interface ChatOptions {
   model?: string;
@@ -26,6 +26,7 @@ interface Props {
   onInterrupt?: () => void;
   isReadOnly?: boolean;
   isGenerating$: Observable<boolean>;
+  hasSession$: Observable<boolean>;
   defaultModel?: string;
   availableModels?: string[];
   autoFocus$: Observable<boolean>;
@@ -36,6 +37,7 @@ export const ChatInput: FC<Props> = ({
   onInterrupt,
   isReadOnly,
   isGenerating$,
+  hasSession$,
   defaultModel = '',
   availableModels = [],
   autoFocus$,
@@ -47,8 +49,33 @@ export const ChatInput: FC<Props> = ({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const isConnected = use$(isConnected$);
-  const isDisabled = isReadOnly || !isConnected;
   const autoFocus = use$(autoFocus$);
+
+  // Get placeholder text
+  const placeholder$ = useObservable(() => {
+    if (isReadOnly) {
+      return 'This is a demo conversation (read-only)';
+    }
+
+    if (!isConnected) {
+      return 'Connect to gptme to send messages';
+    }
+
+    if (!hasSession$.get()) {
+      return 'Waiting for session to be established...';
+    }
+
+    return 'Send a message...';
+  });
+
+  // Check if input should be disabled
+  const isDisabled$ = useObservable(() => {
+    const isReadOnlyOrDisconnected = isReadOnly || !isConnected;
+    if (!isReadOnlyOrDisconnected) {
+      return !hasSession$.get();
+    }
+    return isReadOnlyOrDisconnected;
+  });
 
   // Focus the textarea when autoFocus is true and component is interactive
   useEffect(() => {
@@ -61,7 +88,7 @@ export const ChatInput: FC<Props> = ({
   }, [autoFocus, isReadOnly, isConnected]);
 
   // Global keyboard shortcut for interrupting generation with Escape key
-  useObserveEffect(() => {
+  useEffect(() => {
     const handleGlobalKeyDown = (e: globalThis.KeyboardEvent) => {
       if (e.key === 'Escape' && isGenerating$.get() && onInterrupt) {
         console.log('[ChatInput] Global Escape pressed, interrupting generation...');
@@ -73,7 +100,7 @@ export const ChatInput: FC<Props> = ({
     return () => {
       document.removeEventListener('keydown', handleGlobalKeyDown);
     };
-  });
+  }, [isGenerating$, onInterrupt]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -108,82 +135,82 @@ export const ChatInput: FC<Props> = ({
     }
   };
 
-  const placeholder = isReadOnly
-    ? 'This is a demo conversation (read-only)'
-    : isConnected
-      ? 'Send a message...'
-      : 'Connect to gptme to send messages';
-
   return (
     <form onSubmit={handleSubmit} className="border-t p-4">
       <div className="mx-auto flex max-w-2xl flex-col">
         <div className="flex">
           <div className="flex flex-1">
-            <div className="relative flex flex-1">
-              <Textarea
-                ref={textareaRef}
-                value={message}
-                onChange={(e) => {
-                  setMessage(e.target.value);
-                  // Auto-adjust height
-                  e.target.style.height = 'auto';
-                  e.target.style.height = `${Math.min(e.target.scrollHeight, 400)}px`;
-                }}
-                onKeyDown={handleKeyDown}
-                placeholder={placeholder}
-                className="max-h-[400px] min-h-[60px] resize-none overflow-y-auto pb-8 pr-16"
-                disabled={isDisabled}
-              />
-              <div className="absolute bottom-1.5 left-1.5">
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-5 rounded-sm px-1.5 text-[10px] text-muted-foreground transition-all hover:bg-accent hover:text-muted-foreground hover:opacity-100"
-                      disabled={isDisabled}
-                    >
-                      <Settings className="mr-0.5 h-2.5 w-2.5" />
-                      Options
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-80" align="start">
-                    <div className="space-y-8">
-                      <div className="space-y-1">
-                        <Label htmlFor="model-select">Model</Label>
-                        <Select
-                          value={selectedModel}
-                          onValueChange={setSelectedModel}
-                          disabled={isDisabled}
-                        >
-                          <SelectTrigger id="model-select">
-                            <SelectValue placeholder="Default model" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="default">Default model</SelectItem>
-                            {availableModels.map((model) => (
-                              <SelectItem key={model} value={model}>
-                                {model}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
+            <Computed>
+              {() => {
+                return (
+                  <div className="relative flex flex-1">
+                    <Textarea
+                      ref={textareaRef}
+                      value={message}
+                      onChange={(e) => {
+                        setMessage(e.target.value);
+                        // Auto-adjust height
+                        e.target.style.height = 'auto';
+                        e.target.style.height = `${Math.min(e.target.scrollHeight, 400)}px`;
+                      }}
+                      onKeyDown={handleKeyDown}
+                      placeholder={placeholder$.get()}
+                      className="max-h-[400px] min-h-[60px] resize-none overflow-y-auto pb-8 pr-16"
+                      disabled={isDisabled$.get()}
+                    />
+                    <div className="absolute bottom-1.5 left-1.5">
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-5 rounded-sm px-1.5 text-[10px] text-muted-foreground transition-all hover:bg-accent hover:text-muted-foreground hover:opacity-100"
+                            disabled={isDisabled$.get()}
+                          >
+                            <Settings className="mr-0.5 h-2.5 w-2.5" />
+                            Options
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-80" align="start">
+                          <div className="space-y-8">
+                            <div className="space-y-1">
+                              <Label htmlFor="model-select">Model</Label>
+                              <Select
+                                value={selectedModel}
+                                onValueChange={setSelectedModel}
+                                disabled={isDisabled$.get()}
+                              >
+                                <SelectTrigger id="model-select">
+                                  <SelectValue placeholder="Default model" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="default">Default model</SelectItem>
+                                  {availableModels.map((model) => (
+                                    <SelectItem key={model} value={model}>
+                                      {model}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
 
-                      <div className="flex items-center justify-between">
-                        <Label htmlFor="streaming-toggle">Enable streaming</Label>
-                        <Switch
-                          id="streaming-toggle"
-                          checked={streamingEnabled}
-                          onCheckedChange={setStreamingEnabled}
-                          disabled={isDisabled}
-                        />
-                      </div>
+                            <div className="flex items-center justify-between">
+                              <Label htmlFor="streaming-toggle">Enable streaming</Label>
+                              <Switch
+                                id="streaming-toggle"
+                                checked={streamingEnabled}
+                                onCheckedChange={setStreamingEnabled}
+                                disabled={isDisabled$.get()}
+                              />
+                            </div>
+                          </div>
+                        </PopoverContent>
+                      </Popover>
                     </div>
-                  </PopoverContent>
-                </Popover>
-              </div>
-            </div>
+                  </div>
+                );
+              }}
+            </Computed>
             <div className="relative h-full">
               <Computed>
                 {() => {
@@ -197,7 +224,7 @@ export const ChatInput: FC<Props> = ({
                       : 'h-10 w-10 bg-green-600 text-green-100'
                   }
                 `}
-                      disabled={isDisabled}
+                      disabled={isDisabled$.get()}
                     >
                       {isGenerating$.get() ? (
                         <div className="flex items-center gap-2">

--- a/src/components/ConversationContent.tsx
+++ b/src/components/ConversationContent.tsx
@@ -36,6 +36,7 @@ export const ConversationContent: FC<Props> = ({ conversation }) => {
     pendingTool$,
     confirmTool,
     interruptGeneration,
+    hasSession$,
   } = useConversation(conversation);
 
   // State to track when to auto-focus the input
@@ -223,6 +224,7 @@ export const ConversationContent: FC<Props> = ({ conversation }) => {
         }}
         isReadOnly={conversation.readonly}
         isGenerating$={isGenerating$}
+        hasSession$={hasSession$}
         availableModels={AVAILABLE_MODELS}
         defaultModel={AVAILABLE_MODELS[0]}
         autoFocus$={shouldFocus$}

--- a/src/components/Conversations.tsx
+++ b/src/components/Conversations.tsx
@@ -64,6 +64,7 @@ const Conversations: FC<Props> = ({ route }) => {
     enabled: isConnected,
     staleTime: 0, // Always refetch when query is invalidated
     gcTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 
   // Log any query errors

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -29,6 +29,9 @@ interface ApiContextType {
   // Add event stream methods
   subscribeToEvents: ApiClient['subscribeToEvents'];
   closeEventStream: ApiClient['closeEventStream'];
+  // Add session methods
+  hasSession: ApiClient['hasSession'];
+  getSessionId: ApiClient['getSessionId'];
 }
 
 const ApiContext = createContext<ApiContextType | null>(null);
@@ -213,6 +216,9 @@ export function ApiProvider({
         cancelPendingRequests: api.cancelPendingRequests.bind(api),
         subscribeToEvents: api.subscribeToEvents.bind(api),
         closeEventStream: api.closeEventStream.bind(api),
+        // Add bindings for session methods
+        hasSession: api.hasSession.bind(api),
+        getSessionId: api.getSessionId.bind(api),
       }}
     >
       {children}

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -29,9 +29,6 @@ interface ApiContextType {
   // Add event stream methods
   subscribeToEvents: ApiClient['subscribeToEvents'];
   closeEventStream: ApiClient['closeEventStream'];
-  // Add session methods
-  hasSession: ApiClient['hasSession'];
-  getSessionId: ApiClient['getSessionId'];
 }
 
 const ApiContext = createContext<ApiContextType | null>(null);
@@ -216,9 +213,6 @@ export function ApiProvider({
         cancelPendingRequests: api.cancelPendingRequests.bind(api),
         subscribeToEvents: api.subscribeToEvents.bind(api),
         closeEventStream: api.closeEventStream.bind(api),
-        // Add bindings for session methods
-        hasSession: api.hasSession.bind(api),
-        getSessionId: api.getSessionId.bind(api),
       }}
     >
       {children}

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -252,24 +252,6 @@ export function useConversation(conversation: ConversationItem): UseConversation
       options,
     });
 
-    // Ensure we have a session before proceeding
-    if (!conversation.readonly && !api.hasSession(conversation.name)) {
-      console.log('[useConversation] Waiting for session before sending message');
-
-      try {
-        // This will throw an error if the session can't be established
-        await api.getSessionId(conversation.name);
-      } catch (error) {
-        console.error('[useConversation] Failed to get session:', error);
-        toast({
-          variant: 'destructive',
-          title: 'Session Error',
-          description: 'Could not establish a session. Please try reconnecting.',
-        });
-        return;
-      }
-    }
-
     isGenerating$.set(true);
 
     // Create user message (non-streaming)
@@ -305,9 +287,6 @@ export function useConversation(conversation: ConversationItem): UseConversation
     }
 
     try {
-      // Ensure we're ready to receive events
-      console.log('[useConversation] Ensuring event stream is ready');
-
       isGenerating$.set(true);
 
       // Initial generation


### PR DESCRIPTION
Sometimes getting the session Id fails and thus sending messages just silently fails. Made it so we only enable the ChatInput if we have got the seession ID and retries the connection if we don't get it in 5s.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add retry mechanism for session ID retrieval, enabling chat input only when session ID is available.
> 
>   - **Behavior**:
>     - `ChatInput` now only enables input if a session ID is received, retrying connection if not obtained in 5 seconds.
>     - Placeholder text in `ChatInput` updated to reflect session status.
>   - **Components**:
>     - Added `hasSession$` observable to `ChatInput` and `ConversationContent` to track session status.
>     - Updated `Conversations` to disable `refetchOnWindowFocus` for conversation queries.
>   - **ApiClient**:
>     - Changed `sessions` to `sessions$` observable in `ApiClient`.
>     - Added reconnection logic in `subscribeToEvents()` if session ID is not received.
>   - **Hooks**:
>     - `useConversation` now uses `hasSession$` to track session status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for d364e2ce7d074350828b1a93a03a2671b46acf74. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->