### PR TITLE
feat: add back hasSession$

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -30,6 +30,7 @@ interface Props {
   defaultModel?: string;
   availableModels?: string[];
   autoFocus$: Observable<boolean>;
+  hasSession$: Observable<boolean>;
 }
 
 export const ChatInput: FC<Props> = ({
@@ -40,6 +41,7 @@ export const ChatInput: FC<Props> = ({
   defaultModel = '',
   availableModels = [],
   autoFocus$,
+  hasSession$,
 }) => {
   const [message, setMessage] = useState('');
   const [streamingEnabled, setStreamingEnabled] = useState(true);
@@ -51,14 +53,16 @@ export const ChatInput: FC<Props> = ({
   const autoFocus = use$(autoFocus$);
   const conversation = use$(conversations$.get(conversationId));
   const isGenerating = conversation?.isGenerating || false;
-
+  const hasSession = use$(hasSession$);
   const placeholder = isReadOnly
     ? 'This is a demo conversation (read-only)'
     : !isConnected
       ? 'Connect to gptme to send messages'
-      : 'Send a message...';
+      : !hasSession
+        ? 'Waiting for chat session to be established...'
+        : 'Send a message...';
 
-  const isDisabled = isReadOnly || !isConnected;
+  const isDisabled = isReadOnly || !isConnected || !hasSession;
 
   // Focus the textarea when autoFocus is true and component is interactive
   useEffect(() => {

--- a/src/components/ConversationContent.tsx
+++ b/src/components/ConversationContent.tsx
@@ -39,10 +39,6 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
 
   useObserveEffect(api.sessions$.get(conversationId), () => {
     if (!isReadOnly) {
-      console.log(
-        '[ConversationContent] Session updated:',
-        api.sessions$.get(conversationId).get()
-      );
       hasSession$.set(api.sessions$.get(conversationId).get() !== undefined);
     }
   });

--- a/src/components/ConversationContent.tsx
+++ b/src/components/ConversationContent.tsx
@@ -8,6 +8,7 @@ import { Label } from './ui/label';
 import { ToolConfirmationDialog } from './ToolConfirmationDialog';
 import { For, Memo, useObservable, useObserveEffect } from '@legendapp/state/react';
 import { getObservableIndex } from '@legendapp/state';
+import { useApi } from '@/contexts/ApiContext';
 
 interface Props {
   conversationId: string;
@@ -32,6 +33,19 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
   const shouldFocus$ = useObservable(false);
   // Store the previous conversation ID to detect changes
   const prevConversationIdRef = useRef<string | null>(null);
+
+  const { api } = useApi();
+  const hasSession$ = useObservable<boolean>(false);
+
+  useObserveEffect(api.sessions$.get(conversationId), () => {
+    if (!isReadOnly) {
+      console.log(
+        '[ConversationContent] Session updated:',
+        api.sessions$.get(conversationId).get()
+      );
+      hasSession$.set(api.sessions$.get(conversationId).get() !== undefined);
+    }
+  });
 
   // Detect when the conversation changes and set focus
   useEffect(() => {
@@ -216,6 +230,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
         onSend={handleSendMessage}
         onInterrupt={interruptGeneration}
         isReadOnly={isReadOnly}
+        hasSession$={hasSession$}
         defaultModel={AVAILABLE_MODELS[0]}
         availableModels={AVAILABLE_MODELS}
         autoFocus$={shouldFocus$}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `hasSession$` observable to manage session state in `ChatInput` and `ConversationContent`, affecting input behavior and UI.
> 
>   - **Behavior**:
>     - Adds `hasSession$` observable to `ChatInput` and `ConversationContent` to manage session state.
>     - Updates `ChatInput` placeholder to show 'Waiting for chat session to be established...' when `hasSession$` is false.
>     - Disables `ChatInput` when `hasSession$` is false.
>   - **Components**:
>     - `ChatInput` now accepts `hasSession$` as a prop and uses it to determine input state.
>     - `ConversationContent` initializes and updates `hasSession$` based on `api.sessions$` for the current `conversationId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for b65f6468d131d33332a5364c6cb5acd720d1cd50. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->