### PR TITLE
feat: add back 'Thinking...' indicator until first token

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -216,12 +216,21 @@ export const ChatMessage: FC<Props> = ({
                   <div className={messageClasses$.get()}>
                     <div className="px-3 py-1.5">
                       <Memo>
-                        {() => (
-                          <div
-                            ref={contentRef}
-                            className="chat-message prose prose-sm dark:prose-invert prose-pre:overflow-x-auto prose-pre:max-w-[calc(100vw-16rem)]"
-                          />
-                        )}
+                        {() => {
+                          const isEmptyAssistantMessage =
+                            message$.role.get() === 'assistant' && !message$.content.get();
+
+                          return (
+                            <div
+                              ref={contentRef}
+                              className="chat-message prose prose-sm dark:prose-invert prose-pre:overflow-x-auto prose-pre:max-w-[calc(100vw-16rem)]"
+                            >
+                              {isEmptyAssistantMessage && (
+                                <span className="text-muted-foreground">Thinking...</span>
+                              )}
+                            </div>
+                          );
+                        }}
                       </Memo>
                       {renderFiles()}
                     </div>


### PR DESCRIPTION
Not the prettiest, but style can be improved later, and this is a lot better than nothing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'Thinking...' indicator for empty assistant messages in `ChatMessage` component to improve user feedback.
> 
>   - **UI Enhancement**:
>     - Adds 'Thinking...' indicator for empty assistant messages in `ChatMessage` component.
>     - Checks if `message$.role` is 'assistant' and `message$.content` is empty to display the indicator.
>   - **Code Changes**:
>     - Modifies `ChatMessage.tsx` to include a conditional rendering of the 'Thinking...' span within the message content div.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for aa4b47a552a440382775da95cb1a59d06ae50828. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->