### PR TITLE
feat: added browser to sidebar

### DIFF
--- a/src/components/BrowserPreview.tsx
+++ b/src/components/BrowserPreview.tsx
@@ -1,0 +1,155 @@
+import { RefreshCw, Smartphone, Monitor, Terminal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useState, useEffect, useRef } from 'react';
+import { consoleProxyScript } from '@/utils/consoleProxy';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { FC } from 'react';
+
+interface ConsoleMessage {
+  level: 'log' | 'info' | 'warn' | 'error' | 'debug';
+  args: unknown[];
+  timestamp: number;
+}
+
+interface Props {
+  defaultUrl?: string;
+}
+
+export const BrowserPreview: FC<Props> = ({ defaultUrl = 'http://localhost:8080' }) => {
+  const [url, setUrl] = useState(defaultUrl);
+  const [isMobile, setIsMobile] = useState(false);
+  const [key, setKey] = useState(0); // Used to force iframe refresh
+  const [showConsole, setShowConsole] = useState(true);
+  const [logs, setLogs] = useState<ConsoleMessage[]>([]);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const handleRefresh = () => {
+    setKey((prev) => prev + 1);
+    setLogs([]); // Clear logs on refresh
+  };
+
+  const toggleMode = () => {
+    setIsMobile((prev) => !prev);
+  };
+
+  const toggleConsole = () => {
+    setShowConsole((prev) => !prev);
+  };
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'console') {
+        setLogs((prev) => [
+          ...prev,
+          {
+            level: event.data.level,
+            args: event.data.args,
+            timestamp: Date.now(),
+          },
+        ]);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  // Inject console proxy script when iframe loads
+  const handleIframeLoad = () => {
+    const iframe = iframeRef.current;
+    if (iframe?.contentWindow) {
+      // Use Function constructor instead of eval for better type safety
+      const script = new Function(consoleProxyScript);
+      iframe.contentWindow.document.head.appendChild(
+        Object.assign(document.createElement('script'), {
+          textContent: `(${script.toString()})();`,
+        })
+      );
+    }
+  };
+
+  const clearLogs = () => {
+    setLogs([]);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b p-2">
+        <Input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="flex-1"
+        />
+        <Button variant="ghost" size="icon" onClick={handleRefresh} title="Refresh">
+          <RefreshCw className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggleMode}
+          title={isMobile ? 'Switch to desktop' : 'Switch to mobile'}
+        >
+          {isMobile ? <Smartphone className="h-4 w-4" /> : <Monitor className="h-4 w-4" />}
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggleConsole}
+          title={showConsole ? 'Hide Console' : 'Show Console'}
+        >
+          <Terminal className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className={`relative flex-1 ${showConsole ? 'h-[60%]' : 'h-full'}`}>
+        <div className="h-full border border-foreground/10 bg-muted/30 p-1">
+          <iframe
+            ref={iframeRef}
+            key={key}
+            src={url}
+            onLoad={handleIframeLoad}
+            className={`h-full w-full rounded-sm bg-background shadow-md ${
+              isMobile ? 'mx-auto w-[375px]' : 'w-full'
+            }`}
+            title="Browser Preview"
+          />
+        </div>
+      </div>
+      {showConsole && (
+        <div className="h-[40%] border-t">
+          <div className="flex items-center justify-between border-b px-2 py-1">
+            <span className="text-sm font-medium">Console</span>
+            <div className="flex gap-2">
+              <Button variant="ghost" size="sm" onClick={clearLogs}>
+                Clear
+              </Button>
+            </div>
+          </div>
+          <ScrollArea className="h-[calc(100%-2rem)]">
+            <div className="space-y-1 p-2">
+              {logs.map((log, i) => (
+                <div
+                  key={i}
+                  className={`font-mono text-sm ${
+                    log.level === 'error'
+                      ? 'text-red-500'
+                      : log.level === 'warn'
+                        ? 'text-yellow-500'
+                        : 'text-foreground'
+                  }`}
+                >
+                  {log.args.map((arg, j) => (
+                    <span key={j}>
+                      {typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)}{' '}
+                    </span>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/BrowserPreview.tsx
+++ b/src/components/BrowserPreview.tsx
@@ -30,7 +30,8 @@ export const BrowserPreview: FC<Props> = ({ defaultUrl = 'http://localhost:8080'
   }, [currentUrl]);
 
   const handleRefresh = () => {
-    setCurrentUrl(inputValue);
+    // Force refresh by appending a dummy parameter if URL is unchanged
+    setCurrentUrl(inputValue === currentUrl ? `${inputValue}${inputValue.includes('?') ? '&' : '?'}_refresh=${Date.now()}` : inputValue);
     setLogs([]); // Clear logs on refresh
   };
 

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -1,4 +1,4 @@
-import { PanelRightOpen, PanelRightClose, Monitor, Settings } from 'lucide-react';
+import { PanelRightOpen, PanelRightClose, Monitor, Settings, Globe } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useState } from 'react';
@@ -13,6 +13,7 @@ import type { FC } from 'react';
 import { type Observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
 import { ConversationSettings } from './ConversationSettings';
+import { BrowserPreview } from './BrowserPreview';
 
 const VNC_URL = 'http://localhost:6080/vnc.html';
 
@@ -24,20 +25,28 @@ export const RightSidebar: FC<Props> = ({ isOpen$, onToggle, conversationId }) =
     <div className="relative h-full">
       <div
         className={`border-l transition-all duration-300 ${
-          isOpen ? (activeTab === 'computer' ? 'w-[48rem]' : 'w-[32rem]') : 'w-0'
+          isOpen
+            ? activeTab === 'computer' || activeTab === 'browser'
+              ? 'w-[48rem]'
+              : 'w-[32rem]'
+            : 'w-0'
         } h-full overflow-hidden`}
       >
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex h-full flex-col">
           <div className="flex h-12 items-center justify-between border-b px-4">
             <TabsList>
-              <TabsTrigger value="settings">
-                <Settings className="mr-2 h-4 w-4" />
-                Settings
-              </TabsTrigger>
               <TabsTrigger value="details">Details</TabsTrigger>
+              <TabsTrigger value="browser">
+                <Globe className="mr-2 h-4 w-4" />
+                Browser
+              </TabsTrigger>
               <TabsTrigger value="computer">
                 <Monitor className="mr-2 h-4 w-4" />
                 Computer
+              </TabsTrigger>
+              <TabsTrigger value="settings">
+                <Settings className="mr-2 h-4 w-4" />
+                Settings
               </TabsTrigger>
             </TabsList>
             <Button variant="ghost" size="icon" onClick={onToggle} className="ml-2">
@@ -59,10 +68,14 @@ export const RightSidebar: FC<Props> = ({ isOpen$, onToggle, conversationId }) =
             <TabsContent value="computer" className="m-0 h-full p-0">
               <iframe
                 src={VNC_URL}
-                className="h-full w-full border-0"
+                className="h-full w-full rounded-md border-0 p-1"
                 allow="clipboard-read; clipboard-write"
                 title="VNC Viewer"
               />
+            </TabsContent>
+
+            <TabsContent value="browser" className="m-0 h-full p-0">
+              <BrowserPreview />
             </TabsContent>
           </div>
         </Tabs>

--- a/src/utils/consoleProxy.ts
+++ b/src/utils/consoleProxy.ts
@@ -1,0 +1,52 @@
+// Script to be injected into the iframe to capture console logs
+export const consoleProxyScript = `
+  (function() {
+    const originalConsole = {
+      log: console.log,
+      info: console.info,
+      warn: console.warn,
+      error: console.error,
+      debug: console.debug
+    };
+
+    function proxyConsole(type) {
+      return function(...args) {
+        // Call original console method
+        originalConsole[type].apply(console, args);
+
+        // Forward to parent
+        try {
+          window.parent.postMessage({
+            type: 'console',
+            level: type,
+            args: args.map(arg => {
+              try {
+                // Handle special cases like Error objects
+                if (arg instanceof Error) {
+                  return {
+                    message: arg.message,
+                    stack: arg.stack,
+                    type: 'Error'
+                  };
+                }
+                // Try to serialize the argument
+                return JSON.parse(JSON.stringify(arg));
+              } catch (e) {
+                return String(arg);
+              }
+            })
+          }, '*');
+        } catch (e) {
+          originalConsole.error('Failed to forward console message:', e);
+        }
+      };
+    }
+
+    // Override console methods
+    console.log = proxyConsole('log');
+    console.info = proxyConsole('info');
+    console.warn = proxyConsole('warn');
+    console.error = proxyConsole('error');
+    console.debug = proxyConsole('debug');
+  })();
+`;


### PR DESCRIPTION
Wanted to make something Lovable-lite, this browser sidebar preview is a first step (still needs actual integration with agent, like letting it set a preview URL and read the logs).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `BrowserPreview` component to sidebar for URL preview and console log capture, with updates to `RightSidebar` and a new console proxy script.
> 
>   - **Components**:
>     - Add `BrowserPreview` component in `BrowserPreview.tsx` for URL preview and console log display.
>     - Update `RightSidebar.tsx` to include a new "Browser" tab with `BrowserPreview`.
>   - **Functionality**:
>     - `BrowserPreview` allows URL input, refresh, mobile/desktop toggle, and console visibility toggle.
>     - Captures console logs from iframe using `consoleProxyScript` in `consoleProxy.ts`.
>     - Logs are cleared on URL change or refresh.
>   - **Scripts**:
>     - `consoleProxyScript` captures and forwards console logs from iframe to parent window.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 3095a2d805e26849b3af7ab56450fd8ed182d674. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->