### PR TITLE
feat: added WelcomeView for cleaner conversation starts

### DIFF
--- a/e2e/conversation.spec.ts
+++ b/e2e/conversation.spec.ts
@@ -5,6 +5,9 @@ test.describe('Connecting', () => {
     // Go to the app
     await page.goto('/');
 
+    // Click the left panel toggle button to show conversations
+    await page.getByTestId('toggle-conversations-sidebar').click();
+
     // Should show demo conversations initially
     await expect(page.getByText('Introduction to gptme')).toBeVisible();
 
@@ -19,9 +22,6 @@ test.describe('Connecting', () => {
     await expect(page.getByText(/Hello! I'm gptme, your AI programming assistant/)).toBeVisible();
     await page.goto('/');
 
-    // Should show demo conversations immediately
-    await expect(page.getByText('Introduction to gptme')).toBeVisible();
-
     // Wait for successful connection
     await expect(page.getByRole('button', { name: /Connect/i })).toHaveClass(/text-green-600/, {
       timeout: 10000,
@@ -32,6 +32,7 @@ test.describe('Connecting', () => {
 
     // Wait for conversations to load
     // Should show both demo conversations and connected conversations
+    await page.getByTestId('toggle-conversations-sidebar').click();
     await expect(page.getByText('Introduction to gptme')).toBeVisible();
 
     // Wait for loading state to finish
@@ -71,6 +72,9 @@ test.describe('Connecting', () => {
   test('should handle connection errors gracefully', async ({ page }) => {
     // Start with server unavailable
     await page.goto('/');
+
+    // Click the left panel toggle button to show conversations
+    await page.getByTestId('toggle-conversations-sidebar').click();
 
     // Should still show demo conversations
     await expect(page.getByText('Introduction to gptme')).toBeVisible();
@@ -113,17 +117,15 @@ test.describe('Conversation Flow', () => {
   test('should be able to create a new conversation and send a message', async ({ page }) => {
     await page.goto('/');
 
-    // Click the "New Conversation" button to start a new conversation
-    await page.locator('[data-testid="new-conversation-button"]').click();
-
-    // Wait for the new conversation page to load
-    await expect(page).toHaveURL(/\?conversation=\d+$/);
-
     const message = 'Hello. We are testing, just say exactly "Hello world" without anything else.';
 
     // Type a message
     await page.getByTestId('chat-input').fill(message);
     await page.keyboard.press('Enter');
+    // await page.locator('[data-testid="new-conversation-button"]').click();
+
+    // Wait for the new conversation page to load
+    await expect(page).toHaveURL(/\?conversation=.+$/);
 
     // Should show the message in the conversation
     // Look specifically for the user's message in a user message container

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -107,17 +107,16 @@ export const ConversationList: FC<Props> = ({
               }`}
               onClick={() => onSelect(conv.name)}
             >
-              <div
-                style={{
-                  maskImage:
-                    'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
-                  WebkitMaskImage:
-                    'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
-                }}
-              >
+              <div>
                 <div
                   data-testid="conversation-title"
-                  className="mb-1 overflow-hidden whitespace-nowrap font-medium"
+                  className="mb-1 whitespace-nowrap font-medium"
+                  style={{
+                    maskImage:
+                      'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
+                    WebkitMaskImage:
+                      'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
+                  }}
                 >
                   {stripDate(conv.name)}
                 </div>
@@ -173,7 +172,7 @@ export const ConversationList: FC<Props> = ({
                       <Tooltip>
                         <TooltipTrigger>
                           <span className="flex items-center">
-                            <Signal className="h-4 w-4 text-primary" />
+                            <Signal className="h-3 w-3 text-primary" />
                           </span>
                         </TooltipTrigger>
                         <TooltipContent>Connected</TooltipContent>
@@ -183,7 +182,7 @@ export const ConversationList: FC<Props> = ({
                       <Tooltip>
                         <TooltipTrigger>
                           <span className="flex items-center">
-                            <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                            <Loader2 className="h-3 w-3 animate-spin text-primary" />
                           </span>
                         </TooltipTrigger>
                         <TooltipContent>Generating...</TooltipContent>
@@ -205,7 +204,7 @@ export const ConversationList: FC<Props> = ({
                       <Tooltip>
                         <TooltipTrigger>
                           <span className="flex items-center">
-                            <Lock className="h-4 w-4" />
+                            <Lock className="h-3 w-3" />
                           </span>
                         </TooltipTrigger>
                         <TooltipContent>This conversation is read-only</TooltipContent>

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -102,101 +102,116 @@ export const ConversationList: FC<Props> = ({
 
           return (
             <div
-              className={`cursor-pointer rounded-lg p-3 transition-colors hover:bg-accent ${
+              className={`cursor-pointer rounded-lg py-2 pl-2 transition-colors hover:bg-accent ${
                 isSelected ? 'bg-accent' : ''
               }`}
               onClick={() => onSelect(conv.name)}
             >
-              <div data-testid="conversation-title" className="mb-1 font-medium">
-                {stripDate(conv.name)}
-              </div>
-              <div className="flex items-center space-x-3 text-sm text-muted-foreground">
-                <Tooltip>
-                  <TooltipTrigger>
-                    <time className="flex items-center" dateTime={conv.lastUpdated.toISOString()}>
-                      <Clock className="mr-1 h-4 w-4" />
-                      {getRelativeTimeString(conv.lastUpdated)}
-                    </time>
-                  </TooltipTrigger>
-                  <TooltipContent>{conv.lastUpdated.toLocaleString()}</TooltipContent>
-                </Tooltip>
-                <Computed>
-                  {() => {
-                    const storeConv = conversations$.get(conv.name)?.get();
-                    const isLoaded = storeConv?.data?.log?.length > 0;
+              <div
+                style={{
+                  maskImage:
+                    'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
+                  WebkitMaskImage:
+                    'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
+                }}
+              >
+                <div
+                  data-testid="conversation-title"
+                  className="mb-1 overflow-hidden whitespace-nowrap font-medium"
+                >
+                  {stripDate(conv.name)}
+                </div>
+                <div className="flex items-center space-x-3 text-xs text-muted-foreground">
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <time
+                        className="flex items-center whitespace-nowrap"
+                        dateTime={conv.lastUpdated.toISOString()}
+                      >
+                        <Clock className="mr-1 h-3 w-3" />
+                        {getRelativeTimeString(conv.lastUpdated)}
+                      </time>
+                    </TooltipTrigger>
+                    <TooltipContent>{conv.lastUpdated.toLocaleString()}</TooltipContent>
+                  </Tooltip>
+                  <Computed>
+                    {() => {
+                      const storeConv = conversations$.get(conv.name)?.get();
+                      const isLoaded = storeConv?.data?.log?.length > 0;
 
-                    if (!isLoaded) {
-                      return (
-                        <span className="flex items-center">
-                          <MessageSquare className="mr-1 h-4 w-4" />
-                          {conv.messageCount}
-                        </span>
-                      );
-                    }
-
-                    const breakdown = getMessageBreakdown();
-                    const totalCount = Object.values(breakdown).reduce((a, b) => a + b, 0);
-
-                    return (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
+                      if (!isLoaded) {
+                        return (
                           <span className="flex items-center">
-                            <MessageSquare className="mr-1 h-4 w-4" />
-                            {totalCount}
+                            <MessageSquare className="mr-1 h-3 w-3" />
+                            {conv.messageCount}
+                          </span>
+                        );
+                      }
+
+                      const breakdown = getMessageBreakdown();
+                      const totalCount = Object.values(breakdown).reduce((a, b) => a + b, 0);
+
+                      return (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="flex items-center">
+                              <MessageSquare className="mr-1 h-3 w-3" />
+                              {totalCount}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <div className="whitespace-pre">{formatBreakdown(breakdown)}</div>
+                          </TooltipContent>
+                        </Tooltip>
+                      );
+                    }}
+                  </Computed>
+
+                  {/* Show conversation state indicators */}
+                  <div className="flex items-center space-x-2">
+                    {convState?.isConnected && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <span className="flex items-center">
+                            <Signal className="h-4 w-4 text-primary" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Connected</TooltipContent>
+                      </Tooltip>
+                    )}
+                    {convState?.isGenerating && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <span className="flex items-center">
+                            <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Generating...</TooltipContent>
+                      </Tooltip>
+                    )}
+                    {convState?.pendingTool && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <span className="flex items-center">
+                            <span className="text-lg">⚙️</span>
                           </span>
                         </TooltipTrigger>
                         <TooltipContent>
-                          <div className="whitespace-pre">{formatBreakdown(breakdown)}</div>
+                          Pending tool: {convState.pendingTool.tooluse.tool}
                         </TooltipContent>
                       </Tooltip>
-                    );
-                  }}
-                </Computed>
-
-                {/* Show conversation state indicators */}
-                <div className="flex items-center space-x-2">
-                  {convState?.isConnected && (
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <span className="flex items-center">
-                          <Signal className="h-4 w-4 text-primary" />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>Connected</TooltipContent>
-                    </Tooltip>
-                  )}
-                  {convState?.isGenerating && (
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <span className="flex items-center">
-                          <Loader2 className="h-4 w-4 animate-spin text-primary" />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>Generating...</TooltipContent>
-                    </Tooltip>
-                  )}
-                  {convState?.pendingTool && (
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <span className="flex items-center">
-                          <span className="text-lg">⚙️</span>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        Pending tool: {convState.pendingTool.tooluse.tool}
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                  {conv.readonly && (
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <span className="flex items-center">
-                          <Lock className="h-4 w-4" />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>This conversation is read-only</TooltipContent>
-                    </Tooltip>
-                  )}
+                    )}
+                    {conv.readonly && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <span className="flex items-center">
+                            <Lock className="h-4 w-4" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>This conversation is read-only</TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
@@ -207,7 +222,7 @@ export const ConversationList: FC<Props> = ({
   };
 
   return (
-    <div data-testid="conversation-list" className="h-full space-y-2 overflow-y-auto p-4">
+    <div data-testid="conversation-list" className="h-full space-y-2 overflow-y-auto p-3">
       {isLoading && (
         <div className="flex items-center justify-center p-4 text-sm text-muted-foreground">
           <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/Conversations.tsx
+++ b/src/components/Conversations.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, type FC } from 'react';
 import type { ImperativePanelHandle } from 'react-resizable-panels';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { useCallback, useEffect } from 'react';
+import { WelcomeView } from '@/components/WelcomeView';
 import { setDocumentTitle } from '@/utils/title';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { LeftSidebar } from '@/components/LeftSidebar';
@@ -54,6 +55,9 @@ const Conversations: FC<Props> = ({ route }) => {
     // Handle initial conversation selection
     if (conversationParam) {
       selectedConversation$.set(conversationParam);
+    } else {
+      // Need to use empty string instead of null due to type constraints
+      selectedConversation$.set('');
     }
   }, [conversationParam]);
 
@@ -150,8 +154,9 @@ const Conversations: FC<Props> = ({ route }) => {
 
   // Update conversation$ when available conversations change
   useEffect(() => {
-    const selected = selectedConversation$.get();
-    conversation$.set(allConversations.find((conv) => conv.name === selected));
+    const selectedId = selectedConversation$.get();
+    const selectedConversation = allConversations.find((conv) => conv.name === selectedId);
+    conversation$.set(selectedConversation);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allConversations]);
 
@@ -176,6 +181,13 @@ const Conversations: FC<Props> = ({ route }) => {
       setLeftPanelRef(null);
       setRightPanelRef(null);
     };
+  }, []);
+
+  // Hide left sidebar by default when no conversation is selected
+  useEffect(() => {
+    if (!selectedConversation$.get()) {
+      leftPanelRef.current?.collapse();
+    }
   }, []);
 
   return (
@@ -215,7 +227,11 @@ const Conversations: FC<Props> = ({ route }) => {
                   isReadOnly={conversation.readonly}
                 />
               </div>
-            ) : null;
+            ) : (
+              <div className="flex-1">
+                <WelcomeView onToggleHistory={() => leftPanelRef.current?.expand()} />
+              </div>
+            );
           }}
         </Memo>
       </ResizablePanel>

--- a/src/components/Conversations.tsx
+++ b/src/components/Conversations.tsx
@@ -183,10 +183,11 @@ const Conversations: FC<Props> = ({ route }) => {
     };
   }, []);
 
-  // Hide left sidebar by default when no conversation is selected
+  // Hide sidebars by default when no conversation is selected
   useEffect(() => {
     if (!selectedConversation$.get()) {
       leftPanelRef.current?.collapse();
+      rightPanelRef.current?.collapse();
     }
   }, []);
 
@@ -216,7 +217,7 @@ const Conversations: FC<Props> = ({ route }) => {
 
       <ResizableHandle />
 
-      <ResizablePanel defaultSize={60} minSize={30} className="overflow-hidden">
+      <ResizablePanel defaultSize={60} minSize={30} className="flex items-center overflow-hidden">
         <Memo>
           {() => {
             const conversation = conversation$.get();
@@ -228,7 +229,7 @@ const Conversations: FC<Props> = ({ route }) => {
                 />
               </div>
             ) : (
-              <div className="flex-1">
+              <div className="flex flex-1 items-center justify-center p-4">
                 <WelcomeView onToggleHistory={() => leftPanelRef.current?.expand()} />
               </div>
             );

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -2,10 +2,8 @@ import { Plus, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ConversationList } from './ConversationList';
 import { useApi } from '@/contexts/ApiContext';
-import { useToast } from '@/components/ui/use-toast';
 import { useNavigate } from 'react-router-dom';
 import type { ConversationItem } from './ConversationList';
-import { useQueryClient } from '@tanstack/react-query';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 import type { FC } from 'react';
@@ -33,36 +31,15 @@ export const LeftSidebar: FC<Props> = ({
   onRetry,
   route,
 }) => {
-  const { api, isConnected$ } = useApi();
+  const { isConnected$ } = useApi();
   const isConnected = use$(isConnected$);
-  const { toast } = useToast();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
-  const handleNewConversation = async () => {
-    const newId = Date.now().toString();
-    // Navigate immediately for instant UI feedback
-    navigate(`${route}?conversation=${newId}`);
-
-    // Create conversation in background
-    api
-      .createConversation(newId, [])
-      .then(() => {
-        queryClient.invalidateQueries({ queryKey: ['conversations'] });
-        toast({
-          title: 'New conversation created',
-          description: 'Starting a fresh conversation',
-        });
-      })
-      .catch(() => {
-        toast({
-          variant: 'destructive',
-          title: 'Error',
-          description: 'Failed to create new conversation',
-        });
-        // Optionally navigate back on error
-        navigate(route);
-      });
+  const handleNewConversation = () => {
+    // Clear the conversation parameter to show WelcomeView
+    navigate(route);
+    // Close the sidebar
+    // onToggle();
   };
 
   return (

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -56,7 +56,6 @@ export const LeftSidebar: FC<Props> = ({
                       variant="ghost"
                       size="icon"
                       onClick={handleNewConversation}
-                      disabled={!isConnected}
                       data-testid="new-conversation-button"
                     >
                       <Plus className="h-4 w-4" />

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -24,7 +24,13 @@ export const MenuBar: FC = () => {
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" className="-ml-2" onClick={toggleLeftSidebar}>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="-ml-2"
+                onClick={toggleLeftSidebar}
+                data-testid="toggle-conversations-sidebar"
+              >
                 {leftVisible ? (
                   <PanelLeftClose className="h-4 w-4" />
                 ) : (

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/stores/sidebar';
 import { use$ } from '@legendapp/state/react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Link } from 'react-router-dom';
 
 import type { FC } from 'react';
 
@@ -36,8 +37,10 @@ export const MenuBar: FC = () => {
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
-        <img src="https://gptme.org/media/logo.png" alt="gptme logo" className="w-4" />
-        <span className="font-mono text-base font-semibold">gptme</span>
+        <Link to="/" className="flex items-center space-x-2 transition-opacity hover:opacity-80">
+          <img src="https://gptme.org/media/logo.png" alt="gptme logo" className="w-4" />
+          <span className="font-mono text-base font-semibold">gptme</span>
+        </Link>
       </div>
       <div className="flex items-center gap-4">
         <ConnectionButton />

--- a/src/components/WelcomeView.tsx
+++ b/src/components/WelcomeView.tsx
@@ -1,0 +1,119 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useApi } from '@/contexts/ApiContext';
+import { toast } from 'sonner';
+
+const examples = [
+  'Help me write a Python script',
+  'Debug my code',
+  'Explain a programming concept',
+  'Help me with git',
+];
+
+export const WelcomeView = ({ onToggleHistory }: { onToggleHistory: () => void }) => {
+  const [input, setInput] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const navigate = useNavigate();
+  const { api, isConnected$ } = useApi();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || !isConnected$.get()) return;
+
+    setIsSubmitting(true);
+    try {
+      // Create a new conversation with a timestamp-based ID
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const conversationId = `chat-${timestamp}`;
+
+      await api.createConversation(conversationId, [{ role: 'user', content: input }]);
+
+      // Subscribe to events for the new conversation
+      api.subscribeToEvents(conversationId, {
+        onMessageStart: () => {},
+        onToken: () => {},
+        onMessageComplete: () => {},
+        onMessageAdded: () => {},
+        onToolPending: () => {},
+        onInterrupted: () => {},
+        onError: (error) => {
+          toast.error(`Error: ${error}`);
+        },
+      });
+
+      // Send the initial message
+      await api.sendMessage(conversationId, {
+        role: 'user',
+        content: input,
+      });
+
+      // Start generation
+      await api.step(conversationId);
+
+      // Navigate to the new conversation
+      navigate(`/?conversation=${conversationId}`);
+    } catch (error) {
+      console.error('Failed to create conversation:', error);
+      toast.error('Failed to create conversation. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center">
+      <div className="mx-auto w-full max-w-2xl space-y-8 px-4">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold">How can I help you today?</h1>
+          <p className="mt-2 text-muted-foreground">
+            I can help you write code, debug issues, and learn new concepts.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type your message here..."
+            className="h-12 text-lg"
+            disabled={isSubmitting || !isConnected$.get()}
+          />
+          <div className="flex justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onToggleHistory}
+              className="text-muted-foreground"
+            >
+              Show history
+            </Button>
+            <Button type="submit" disabled={!input.trim() || isSubmitting || !isConnected$.get()}>
+              {isSubmitting ? 'Sending...' : 'Send message'}
+            </Button>
+          </div>
+        </form>
+
+        <div className="space-y-4">
+          <h2 className="text-center text-sm text-muted-foreground">
+            Here are some examples to get you started:
+          </h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {examples.map((example) => (
+              <Button
+                key={example}
+                variant="outline"
+                className="h-auto whitespace-normal p-4 text-left"
+                onClick={() => setInput(example)}
+                disabled={isSubmitting}
+              >
+                {example}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/WelcomeView.tsx
+++ b/src/components/WelcomeView.tsx
@@ -70,6 +70,7 @@ export const WelcomeView = ({ onToggleHistory }: { onToggleHistory: () => void }
             placeholder="Type your message here..."
             className="h-12 text-lg"
             disabled={isSubmitting || !isConnected}
+            data-testid="chat-input"
           />
           <div className="flex justify-between">
             <Button
@@ -80,7 +81,11 @@ export const WelcomeView = ({ onToggleHistory }: { onToggleHistory: () => void }
             >
               Show history
             </Button>
-            <Button type="submit" disabled={!input.trim() || isSubmitting || !isConnected}>
+            <Button
+              type="submit"
+              disabled={!input.trim() || isSubmitting || !isConnected}
+              data-testid="new-conversation-button"
+            >
               {isSubmitting ? 'Sending...' : 'Send message'}
             </Button>
           </div>

--- a/src/utils/__tests__/markdownRenderer.test.ts
+++ b/src/utils/__tests__/markdownRenderer.test.ts
@@ -61,7 +61,7 @@ describe('renderThinkingBlocks', () => {
     //   </p>
     // </div>
     const expected =
-      '<p><details type="thinking" open="true"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details> some other text</p>';
+      '<p><details type="thinking"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details> some other text</p>';
 
     let div = parse(markdown);
     expect(div.innerHTML).toBe(expected);
@@ -84,7 +84,7 @@ describe('renderThinkingBlocks', () => {
     //   </p>
     // </div>
     const expected =
-      '<p>some other text <details type="thinking" open="true"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details></p>';
+      '<p>some other text <details type="thinking"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details></p>';
 
     let div = parse(markdown);
     expect(div.innerHTML).toBe(expected);
@@ -112,7 +112,7 @@ describe('renderThinkingBlocks', () => {
     //   </p>
     // </div>
     const expected =
-      '<p>some other text <details type="thinking" open="true"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details> some other text <details type="thinking" open="true"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is another thinking block</div></details></p>';
+      '<p>some other text <details type="thinking"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is a thinking block</div></details> some other text <details type="thinking"><summary>💭 Thinking</summary><div style="white-space: pre-wrap; padding-top: 0px; padding-bottom: 0.5rem;">This is another thinking block</div></details></p>';
 
     const div = parse(markdown);
     expect(div.innerHTML).toBe(expected);
@@ -157,8 +157,7 @@ describe('renderMarkdownBlocks', () => {
     const expected =
       '<details open="true"><summary>💻 markdown</summary><pre><code class="hljs language-markdown">This is a markdown block</code></pre></details><p>some other text</p>';
 
-    let div = parse(markdown, false, true);
-    console.log(div.innerHTML);
+    let div = parse(markdown, false, false);
     expect(div.innerHTML).toBe(expected);
 
     div = parse(markdown, true, false);


### PR DESCRIPTION
Depends on https://github.com/gptme/gptme/pull/547

TODO

 - [ ] Re-use ChatInput component for input
 - [ ] Better examples (don't we already have some in ChatInput?)
 - [ ] Better styling
 - [x] Make it actually possible to create a new conversation (broken)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `WelcomeView` for starting new conversations, updates UI components, and refines tests to support the new flow.
> 
>   - **New Feature**:
>     - Adds `WelcomeView` component in `WelcomeView.tsx` for initiating new conversations with example prompts and input field.
>     - Integrates `WelcomeView` into `Conversations.tsx` to display when no conversation is selected.
>   - **UI Changes**:
>     - Updates `ConversationList.tsx` to improve styling and tooltip information for conversation items.
>     - Modifies `LeftSidebar.tsx` to handle new conversation creation by clearing the conversation parameter.
>     - Adds toggle functionality for sidebars in `MenuBar.tsx`.
>   - **Tests**:
>     - Updates `conversation.spec.ts` to test new conversation creation flow and sidebar toggle behavior.
>     - Adjusts `markdownRenderer.test.ts` to fix expected output for thinking blocks.
>   - **Misc**:
>     - Refactors conversation initialization and selection logic in `Conversations.tsx` to support `WelcomeView` and step parameter handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 6ae58f22bf54fc03c43c48e4013e1f5238fd3ee7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->