### PR TITLE
feat: added workspace file browser

### DIFF
--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -1,4 +1,11 @@
-import { PanelRightOpen, PanelRightClose, Monitor, Settings, Globe } from 'lucide-react';
+import {
+  PanelRightOpen,
+  PanelRightClose,
+  Monitor,
+  Settings,
+  Globe,
+  FolderOpen,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useState } from 'react';
@@ -14,6 +21,7 @@ import { type Observable } from '@legendapp/state';
 import { use$ } from '@legendapp/state/react';
 import { ConversationSettings } from './ConversationSettings';
 import { BrowserPreview } from './BrowserPreview';
+import { WorkspaceExplorer } from './workspace/WorkspaceExplorer';
 
 const VNC_URL = 'http://localhost:6080/vnc.html';
 
@@ -26,7 +34,7 @@ export const RightSidebar: FC<Props> = ({ isOpen$, onToggle, conversationId }) =
       <div
         className={`border-l transition-all duration-300 ${
           isOpen
-            ? activeTab === 'computer' || activeTab === 'browser'
+            ? activeTab === 'computer' || activeTab === 'browser' || activeTab === 'workspace'
               ? 'w-[48rem]'
               : 'w-[32rem]'
             : 'w-0'
@@ -35,7 +43,10 @@ export const RightSidebar: FC<Props> = ({ isOpen$, onToggle, conversationId }) =
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex h-full flex-col">
           <div className="flex h-12 items-center justify-between border-b px-4">
             <TabsList>
-              <TabsTrigger value="details">Details</TabsTrigger>
+              <TabsTrigger value="workspace">
+                <FolderOpen className="mr-2 h-4 w-4" />
+                Workspace
+              </TabsTrigger>
               <TabsTrigger value="browser">
                 <Globe className="mr-2 h-4 w-4" />
                 Browser
@@ -54,15 +65,13 @@ export const RightSidebar: FC<Props> = ({ isOpen$, onToggle, conversationId }) =
             </Button>
           </div>
 
-          <div className="h-[calc(100%-3rem)] overflow-y-auto">
+          <div className="h-[calc(100%-3rem)]">
             <TabsContent value="settings" className="m-0 h-full p-4">
               <ConversationSettings conversationId={conversationId} />
             </TabsContent>
 
-            <TabsContent value="details" className="m-0 h-full p-4">
-              <div className="text-sm text-muted-foreground">
-                Select a file or tool to view details
-              </div>
+            <TabsContent value="workspace" className="m-0 h-full">
+              <WorkspaceExplorer conversationId={conversationId} />
             </TabsContent>
 
             <TabsContent value="computer" className="m-0 h-full p-0">

--- a/src/components/workspace/FileList.tsx
+++ b/src/components/workspace/FileList.tsx
@@ -1,0 +1,59 @@
+import { FileIcon, FolderIcon, ArrowLeft } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { FileType } from '@/types/workspace';
+
+interface FileListProps {
+  files: FileType[];
+  currentPath: string;
+  onFileClick: (file: FileType) => void;
+  onDirectoryClick: (path: string) => void;
+}
+
+export function FileList({ files, currentPath, onFileClick, onDirectoryClick }: FileListProps) {
+  const goToParent = () => {
+    if (!currentPath) return;
+    const parentPath = currentPath.split('/').slice(0, -1).join('/');
+    onDirectoryClick(parentPath);
+  };
+
+  return (
+    <ScrollArea className="h-full px-2">
+      <div className="space-y-1 py-2">
+        {currentPath && (
+          <button
+            onClick={goToParent}
+            className="flex w-full items-center justify-between rounded-md p-2 hover:bg-muted"
+          >
+            <div className="flex items-center">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              <span>..</span>
+            </div>
+          </button>
+        )}
+        {files.map((file) => (
+          <button
+            key={file.path}
+            onClick={() =>
+              file.type === 'directory' ? onDirectoryClick(file.path) : onFileClick(file)
+            }
+            className="flex w-full items-center justify-between rounded-md p-2 hover:bg-muted"
+          >
+            <div className="flex items-center">
+              {file.type === 'directory' ? (
+                <FolderIcon className="mr-2 h-4 w-4" />
+              ) : (
+                <FileIcon className="mr-2 h-4 w-4" />
+              )}
+              <span className="text-sm">{file.name}</span>
+            </div>
+            <div className="flex items-center space-x-4 text-xs text-muted-foreground">
+              <span>{formatDistanceToNow(new Date(file.modified), { addSuffix: true })}</span>
+              {file.type === 'file' && <span>{(file.size / 1024).toFixed(1)} KB</span>}
+            </div>
+          </button>
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/components/workspace/FilePreview.tsx
+++ b/src/components/workspace/FilePreview.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useWorkspaceApi } from '@/utils/workspaceApi';
+import type { FileType, FilePreview } from '@/types/workspace';
+import { CodeDisplay } from '@/components/CodeDisplay';
+
+interface FilePreviewProps {
+  file: FileType;
+  conversationId: string;
+}
+
+export function FilePreview({ file, conversationId }: FilePreviewProps) {
+  const [preview, setPreview] = useState<FilePreview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const { previewFile } = useWorkspaceApi();
+
+  const loadPreview = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await previewFile(conversationId, file.path);
+      setPreview(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load preview');
+    } finally {
+      setLoading(false);
+    }
+  }, [file.path, conversationId, previewFile]);
+
+  useEffect(() => {
+    loadPreview();
+  }, [loadPreview]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="flex h-full items-center justify-center text-destructive">{error}</div>;
+  }
+
+  if (!preview) {
+    return null;
+  }
+
+  switch (preview.type) {
+    case 'text':
+      return (
+        <div className="flex h-full flex-col">
+          <div className="border-b p-2">
+            <h3 className="font-medium">{file.name}</h3>
+            <div className="text-sm text-muted-foreground">
+              {(file.size / 1024).toFixed(1)} KB • {file.mime_type || 'Unknown type'}
+            </div>
+          </div>
+          <div className="flex-1 overflow-auto">
+            <CodeDisplay
+              code={preview.content}
+              language={file.mime_type?.split('/')[1] || 'plaintext'}
+              maxHeight="none"
+            />
+          </div>
+        </div>
+      );
+    case 'image':
+      return (
+        <div className="flex h-full flex-col">
+          <div className="border-b p-2">
+            <h3 className="font-medium">{file.name}</h3>
+            <div className="text-sm text-muted-foreground">
+              {(file.size / 1024).toFixed(1)} KB • {file.mime_type || 'Unknown type'}
+            </div>
+          </div>
+          <div className="flex flex-1 items-center justify-center overflow-auto p-4">
+            <img
+              src={preview.content}
+              alt={file.name}
+              className="max-h-full max-w-full object-contain"
+            />
+          </div>
+        </div>
+      );
+    case 'binary':
+      return (
+        <div className="flex h-full flex-col">
+          <div className="border-b p-2">
+            <h3 className="font-medium">{file.name}</h3>
+            <div className="text-sm text-muted-foreground">
+              {(file.size / 1024).toFixed(1)} KB • {file.mime_type || 'Unknown type'}
+            </div>
+          </div>
+          <div className="flex flex-1 items-center justify-center">
+            <p className="text-muted-foreground">Binary file</p>
+          </div>
+        </div>
+      );
+    default:
+      return null;
+  }
+}

--- a/src/components/workspace/PathSegments.tsx
+++ b/src/components/workspace/PathSegments.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/components/ui/button';
+import { ChevronRight } from 'lucide-react';
+
+interface PathSegmentsProps {
+  path: string;
+  onNavigate: (path: string) => void;
+}
+
+export function PathSegments({ path, onNavigate }: PathSegmentsProps) {
+  const segments = path ? path.split('/') : [];
+
+  return (
+    <div className="flex items-center space-x-1 text-sm">
+      <Button variant="ghost" size="sm" className="h-6 px-2" onClick={() => onNavigate('')}>
+        /
+      </Button>
+      {segments.map((segment, index) => {
+        if (!segment) return null;
+        const segmentPath = segments.slice(0, index + 1).join('/');
+        return (
+          <div key={segmentPath} className="flex items-center">
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2"
+              onClick={() => onNavigate(segmentPath)}
+            >
+              {segment}
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/workspace/WorkspaceExplorer.tsx
+++ b/src/components/workspace/WorkspaceExplorer.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useWorkspaceApi } from '@/utils/workspaceApi';
+import { FileList } from './FileList';
+import { FilePreview } from './FilePreview';
+import { PathSegments } from './PathSegments';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import type { FileType } from '@/types/workspace';
+
+interface WorkspaceExplorerProps {
+  conversationId: string;
+}
+
+export function WorkspaceExplorer({ conversationId }: WorkspaceExplorerProps) {
+  const [files, setFiles] = useState<FileType[]>([]);
+  const [currentPath, setCurrentPath] = useState('');
+  const [selectedFile, setSelectedFile] = useState<FileType | null>(null);
+  const [showHidden, setShowHidden] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { listWorkspace } = useWorkspaceApi();
+
+  const loadFiles = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await listWorkspace(conversationId, currentPath, showHidden);
+      setFiles(data);
+    } catch (err) {
+      console.error('Error loading workspace:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load workspace');
+    } finally {
+      setLoading(false);
+    }
+  }, [conversationId, currentPath, showHidden, listWorkspace]);
+
+  useEffect(() => {
+    loadFiles();
+  }, [loadFiles]);
+
+  const handleFileClick = (file: FileType) => {
+    setSelectedFile(file);
+  };
+
+  const handleDirectoryClick = (path: string) => {
+    setCurrentPath(path);
+    setSelectedFile(null);
+  };
+
+  if (error) {
+    return <div className="flex h-full items-center justify-center text-destructive">{error}</div>;
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b p-4">
+        <PathSegments path={currentPath} onNavigate={handleDirectoryClick} />
+        <div className="flex items-center space-x-2">
+          <Switch id="show-hidden" checked={showHidden} onCheckedChange={setShowHidden} />
+          <Label htmlFor="show-hidden">Show hidden files</Label>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="h-full w-1/2 overflow-hidden border-r">
+          {loading ? (
+            <div className="flex h-full items-center justify-center">
+              <Loader2 className="h-6 w-6 animate-spin" />
+            </div>
+          ) : (
+            <FileList
+              files={files}
+              currentPath={currentPath}
+              onFileClick={handleFileClick}
+              onDirectoryClick={handleDirectoryClick}
+            />
+          )}
+        </div>
+        <div className="h-full w-1/2 overflow-hidden">
+          {selectedFile ? (
+            <FilePreview file={selectedFile} conversationId={conversationId} />
+          ) : (
+            <div className="flex h-full items-center justify-center text-muted-foreground">
+              Select a file to preview
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -1,0 +1,25 @@
+export interface FileType {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  size: number;
+  modified: string;
+  mime_type: string | null;
+}
+
+export interface TextPreview {
+  type: 'text';
+  content: string;
+}
+
+export interface BinaryPreview {
+  type: 'binary';
+  metadata: FileType;
+}
+
+export interface ImagePreview {
+  type: 'image';
+  content: string; // Blob URL
+}
+
+export type FilePreview = TextPreview | BinaryPreview | ImagePreview;

--- a/src/utils/workspaceApi.ts
+++ b/src/utils/workspaceApi.ts
@@ -1,0 +1,63 @@
+import type { FileType, FilePreview } from '@/types/workspace';
+import { useApi } from '@/contexts/ApiContext';
+import { useMemo } from 'react';
+
+export function useWorkspaceApi() {
+  const { api } = useApi();
+
+  return useMemo(() => {
+    async function listWorkspace(
+      conversationId: string,
+      path?: string,
+      showHidden = false
+    ): Promise<FileType[]> {
+      const url = new URL(
+        `/api/v2/conversations/${conversationId}/workspace${path ? `/${path}` : ''}`,
+        api.baseUrl
+      );
+      url.searchParams.set('show_hidden', showHidden.toString());
+
+      const response = await fetch(url, {
+        headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to list workspace');
+      }
+
+      return response.json();
+    }
+
+    async function previewFile(conversationId: string, path: string): Promise<FilePreview> {
+      const url = new URL(
+        `/api/v2/conversations/${conversationId}/workspace/${path}/preview`,
+        api.baseUrl
+      );
+
+      const response = await fetch(url, {
+        headers: api.authHeader ? { Authorization: api.authHeader } : undefined,
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to preview file');
+      }
+
+      const contentType = response.headers.get('Content-Type');
+      if (contentType?.startsWith('image/')) {
+        return {
+          type: 'image',
+          content: URL.createObjectURL(await response.blob()),
+        };
+      }
+
+      return response.json();
+    }
+
+    return {
+      listWorkspace,
+      previewFile,
+    };
+  }, [api.baseUrl, api.authHeader]);
+}


### PR DESCRIPTION
Depends on: https://github.com/gptme/gptme/pull/530

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a workspace file browser with navigation and preview capabilities to the application.
> 
>   - **Feature**:
>     - Adds `WorkspaceExplorer` component to `RightSidebar.tsx` for browsing workspace files.
>     - Introduces `FileList`, `FilePreview`, and `PathSegments` components in `workspace` directory for file navigation and preview.
>     - Adds `useWorkspaceApi` in `workspaceApi.ts` for API interactions to list and preview files.
>   - **UI**:
>     - New 'Workspace' tab in `RightSidebar.tsx` with `FolderOpen` icon.
>     - `FileList` displays files and directories, supports navigation to parent directory.
>     - `FilePreview` supports text, image, and binary file previews.
>     - `PathSegments` allows navigation through directory path segments.
>   - **Types**:
>     - Defines `FileType`, `TextPreview`, `BinaryPreview`, `ImagePreview`, and `FilePreview` in `workspace.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for d32da16a8ee46d83cb0261250993781e9b902e75. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->