### PR TITLE
fix: moved the conversation delete button into conversation settings

### DIFF
--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -1,4 +1,4 @@
-import { Clock, MessageSquare, Lock, Loader2, Signal, Trash } from 'lucide-react';
+import { Clock, MessageSquare, Lock, Loader2, Signal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { getRelativeTimeString } from '@/utils/time';
@@ -6,11 +6,10 @@ import { useApi } from '@/contexts/ApiContext';
 import { demoConversations } from '@/democonversations';
 
 import type { MessageRole } from '@/types/conversation';
-import { useState, type FC } from 'react';
+import { type FC } from 'react';
 import { Computed, use$ } from '@legendapp/state/react';
 import { type Observable } from '@legendapp/state';
 import { conversations$ } from '@/stores/conversations';
-import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
 
 type MessageBreakdown = Partial<Record<MessageRole, number>>;
 
@@ -43,9 +42,6 @@ export const ConversationList: FC<Props> = ({
 }) => {
   const { isConnected$ } = useApi();
   const isConnected = use$(isConnected$);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [conversationToDelete, setConversationToDelete] = useState<string | null>(null);
-
   if (!conversations) {
     return null;
   }
@@ -201,23 +197,6 @@ export const ConversationList: FC<Props> = ({
                       <TooltipContent>This conversation is read-only</TooltipContent>
                     </Tooltip>
                   )}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label="Delete conversation"
-                        className="flex items-center"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setConversationToDelete(conv.name);
-                          setDeleteDialogOpen(true);
-                        }}
-                      >
-                        <Trash className="h-4 w-4" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>Delete conversation</TooltipContent>
-                  </Tooltip>
                 </div>
               </div>
             </div>
@@ -229,14 +208,6 @@ export const ConversationList: FC<Props> = ({
 
   return (
     <div data-testid="conversation-list" className="h-full space-y-2 overflow-y-auto p-4">
-      <DeleteConversationConfirmationDialog
-        conversationName={conversationToDelete ?? ''}
-        open={deleteDialogOpen}
-        onOpenChange={setDeleteDialogOpen}
-        onDelete={() => {
-          setConversationToDelete(null);
-        }}
-      />
       {isLoading && (
         <div className="flex items-center justify-center p-4 text-sm text-muted-foreground">
           <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/ConversationSettings.tsx
+++ b/src/components/ConversationSettings.tsx
@@ -2,6 +2,8 @@ import { use$ } from '@legendapp/state/react';
 import { conversations$, updateConversation } from '@/stores/conversations';
 import { useEffect, useState, type FC } from 'react';
 import { useApi } from '@/contexts/ApiContext';
+import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
+import { Trash } from 'lucide-react';
 import { AVAILABLE_MODELS } from './ConversationContent';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { z } from 'zod';
@@ -88,6 +90,7 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
 
   const [toolsOpen, setToolsOpen] = useState(false);
   const [mcpOpen, setMcpOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   console.log('chatConfig', chatConfig);
 
@@ -947,7 +950,32 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                   </CollapsibleContent>
                 </FormItem>
               </Collapsible>
+
+              {/* Danger Zone */}
+              <div className="mt-8 space-y-6">
+                <h3 className="text-lg font-medium text-destructive">Danger Zone</h3>
+                <div className="rounded-lg border-2 border-destructive/20 p-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h4 className="font-medium">Delete Conversation</h4>
+                      <p className="text-sm text-muted-foreground">
+                        Permanently delete this conversation and all its messages.
+                      </p>
+                    </div>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => setDeleteDialogOpen(true)}
+                      className="shrink-0"
+                    >
+                      <Trash className="mr-2 h-4 w-4" />
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              </div>
             </div>
+
             {/* Submit Button */}
             <div className="sticky bottom-0 mt-auto border-t bg-background p-4">
               <Button
@@ -968,6 +996,17 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
                 )}
               </Button>
             </div>
+
+            {/* Delete Dialog */}
+            <DeleteConversationConfirmationDialog
+              conversationName={conversationId}
+              open={deleteDialogOpen}
+              onOpenChange={setDeleteDialogOpen}
+              onDelete={() => {
+                // Handle post-deletion navigation or UI updates
+                window.location.href = '/';
+              }}
+            />
           </form>
         </Form>
       )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move conversation delete button from `ConversationList` to `ConversationSettings` and adjust related state management.
> 
>   - **UI Changes**:
>     - Move delete button from `ConversationList` to `ConversationSettings`.
>     - Add "Danger Zone" section in `ConversationSettings` for delete action.
>   - **State Management**:
>     - Remove `deleteDialogOpen` and `conversationToDelete` state from `ConversationList`.
>     - Add `deleteDialogOpen` state to `ConversationSettings`.
>   - **Imports**:
>     - Remove `Trash` and `DeleteConversationConfirmationDialog` imports from `ConversationList.tsx`.
>     - Add `Trash` and `DeleteConversationConfirmationDialog` imports to `ConversationSettings.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 6ee109776a51ec79b77637c6b8b3f9c02b26bd83. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->