### PR TITLE
feat: added support for conversation display names (separate id and name)

### DIFF
--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -106,10 +106,7 @@ export const ConversationList: FC<Props> = ({
               className={`cursor-pointer rounded-lg py-2 pl-2 transition-colors hover:bg-accent ${
                 isSelected ? 'bg-accent' : ''
               }`}
-              onClick={() => {
-                console.log(conv);
-                onSelect(conv.id);
-              }}
+              onClick={() => onSelect(conv.id)}
             >
               <div>
                 <div

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -15,6 +15,7 @@ type MessageBreakdown = Partial<Record<MessageRole, number>>;
 
 // UI-specific type for rendering conversations
 export interface ConversationItem {
+  id: string;
   name: string;
   lastUpdated: Date;
   messageCount: number;
@@ -54,7 +55,7 @@ export const ConversationList: FC<Props> = ({
 
   const ConversationItem: FC<{ conv: ConversationItem }> = ({ conv }) => {
     // For demo conversations, get messages from demoConversations
-    const demoConv = demoConversations.find((dc) => dc.name === conv.name);
+    const demoConv = demoConversations.find((dc) => dc.id === conv.id);
 
     // For API conversations, fetch messages
     const getMessageBreakdown = (): MessageBreakdown => {
@@ -66,7 +67,7 @@ export const ConversationList: FC<Props> = ({
       }
 
       // Get messages from store
-      const storeConv = conversations$.get(conv.name)?.get();
+      const storeConv = conversations$.get(conv.id)?.get();
       // Return empty breakdown if conversation or data is not loaded yet
       if (!storeConv?.data?.log) return {};
 
@@ -97,15 +98,18 @@ export const ConversationList: FC<Props> = ({
     return (
       <Computed>
         {() => {
-          const convState = conversations$.get(conv.name)?.get();
-          const isSelected = selectedId$?.get() === conv.name;
+          const convState = conversations$.get(conv.id)?.get();
+          const isSelected = selectedId$?.get() === conv.id;
 
           return (
             <div
               className={`cursor-pointer rounded-lg py-2 pl-2 transition-colors hover:bg-accent ${
                 isSelected ? 'bg-accent' : ''
               }`}
-              onClick={() => onSelect(conv.name)}
+              onClick={() => {
+                console.log(conv);
+                onSelect(conv.id);
+              }}
             >
               <div>
                 <div
@@ -118,7 +122,7 @@ export const ConversationList: FC<Props> = ({
                       'linear-gradient(to right, black 0%, black calc(100% - 2rem), transparent 100%)',
                   }}
                 >
-                  {stripDate(conv.name)}
+                  {conv.name || stripDate(conv.id)}
                 </div>
                 <div className="flex items-center space-x-3 text-xs text-muted-foreground">
                   <Tooltip>
@@ -135,7 +139,7 @@ export const ConversationList: FC<Props> = ({
                   </Tooltip>
                   <Computed>
                     {() => {
-                      const storeConv = conversations$.get(conv.name)?.get();
+                      const storeConv = conversations$.get(conv.id)?.get();
                       const isLoaded = storeConv?.data?.log?.length > 0;
 
                       if (!isLoaded) {
@@ -252,7 +256,7 @@ export const ConversationList: FC<Props> = ({
       )}
       {!isLoading &&
         !isError &&
-        conversations.map((conv) => <ConversationItem key={conv.name} conv={conv} />)}
+        conversations.map((conv) => <ConversationItem key={conv.id} conv={conv} />)}
     </div>
   );
 };

--- a/src/components/Conversations.tsx
+++ b/src/components/Conversations.tsx
@@ -47,7 +47,9 @@ const Conversations: FC<Props> = ({ route }) => {
   useEffect(() => {
     // Initialize demos in store
     demoConversations.forEach((conv) => {
-      initConversation(conv.name, {
+      initConversation(conv.id, {
+        id: conv.id,
+        name: conv.name,
         log: conv.messages,
         logfile: conv.name,
         branches: {},
@@ -126,9 +128,10 @@ const Conversations: FC<Props> = ({ route }) => {
   }
 
   // Prepare demo conversation items
-  const demoItems = useMemo(
+  const demoItems: ConversationItem[] = useMemo(
     () =>
       demoConversations.map((conv: DemoConversation) => ({
+        id: conv.id,
         name: conv.name,
         lastUpdated: conv.lastUpdated,
         messageCount: conv.messages.length,
@@ -138,7 +141,7 @@ const Conversations: FC<Props> = ({ route }) => {
   );
 
   // Handle API conversations separately
-  const apiItems = useMemo(() => {
+  const apiItems: ConversationItem[] = useMemo(() => {
     if (!isConnected) return [];
     return toConversationItems(apiConversations);
   }, [isConnected, apiConversations]);
@@ -149,14 +152,14 @@ const Conversations: FC<Props> = ({ route }) => {
       console.log('[Conversations] Initializing API conversations');
       void initializeConversations(
         api,
-        apiConversations.map((c) => c.name),
+        apiConversations.map((c) => c.id),
         10
       );
     }
   }, [isConnected, apiConversations, api]);
 
   // Combine demo and API conversations
-  const allConversations = useMemo(() => {
+  const allConversations: ConversationItem[] = useMemo(() => {
     console.log('[Conversations] Combining conversations', {
       demoCount: demoItems.length,
       apiCount: apiItems.length,
@@ -183,13 +186,13 @@ const Conversations: FC<Props> = ({ route }) => {
 
   // Update conversation$ when selected conversation changes
   useObserveEffect(selectedConversation$, ({ value: selectedConversation }) => {
-    conversation$.set(allConversations.find((conv) => conv.name === selectedConversation));
+    conversation$.set(allConversations.find((conv) => conv.id === selectedConversation));
   });
 
   // Update conversation$ when available conversations change
   useEffect(() => {
     const selectedId = selectedConversation$.get();
-    const selectedConversation = allConversations.find((conv) => conv.name === selectedId);
+    const selectedConversation = allConversations.find((conv) => conv.id === selectedId);
     conversation$.set(selectedConversation);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allConversations]);
@@ -258,7 +261,7 @@ const Conversations: FC<Props> = ({ route }) => {
             return conversation ? (
               <div className="h-full overflow-auto">
                 <ConversationContent
-                  conversationId={conversation.name}
+                  conversationId={conversation.id}
                   isReadOnly={conversation.readonly}
                 />
               </div>
@@ -286,7 +289,7 @@ const Conversations: FC<Props> = ({ route }) => {
         <Memo>
           {() => {
             const conversation = conversation$.get();
-            return conversation ? <RightSidebar conversationId={conversation.name} /> : null;
+            return conversation ? <RightSidebar conversationId={conversation.id} /> : null;
           }}
         </Memo>
       </ResizablePanel>

--- a/src/democonversations.ts
+++ b/src/democonversations.ts
@@ -1,6 +1,7 @@
 import type { Message } from '@/types/conversation';
 
 export interface DemoConversation {
+  id: string;
   name: string;
   lastUpdated: Date;
   messages: Message[];
@@ -11,6 +12,7 @@ const now = new Date();
 // Demo conversations (read-only)
 export const demoConversations: DemoConversation[] = [
   {
+    id: 'introduction',
     name: 'Introduction to gptme',
     lastUpdated: now,
     messages: [

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -46,6 +46,8 @@ export function useConversation(conversationId: string) {
           // Initialize with demo data
           updateConversation(conversationId, {
             data: {
+              id: conversationId,
+              name: demoConv.name,
               log: demoConv.messages,
               logfile: conversationId,
               branches: {},

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -41,7 +41,7 @@ export function useConversation(conversationId: string) {
     const loadAndConnect = async () => {
       try {
         // Check if this is a demo conversation
-        const demoConv = demoConversations.find((conv) => conv.name === conversationId);
+        const demoConv = demoConversations.find((conv) => conv.id === conversationId);
         if (demoConv) {
           // Initialize with demo data
           updateConversation(conversationId, {

--- a/src/stores/conversations.ts
+++ b/src/stores/conversations.ts
@@ -30,14 +30,14 @@ export interface ConversationState {
 export const conversations$ = observable(new Map<string, ConversationState>());
 
 // Currently selected conversation
-export const selectedConversation$ = observable<string>(demoConversations[0].name);
+export const selectedConversation$ = observable<string>(demoConversations[0].id);
 
 // Helper functions
 export function updateConversation(id: string, update: Partial<ConversationState>) {
   if (!conversations$.get(id)) {
     // Initialize with defaults if conversation doesn't exist
     conversations$.set(id, {
-      data: { log: [], logfile: id, branches: {} },
+      data: { id, name: '', log: [], logfile: id, branches: {} },
       isGenerating: false,
       isConnected: false,
       pendingTool: null,
@@ -72,7 +72,7 @@ export function setPendingTool(id: string, toolId: string | null, tooluse: ToolU
 // Initialize a new conversation in the store
 export function initConversation(id: string, data?: ConversationResponse) {
   const initial: ConversationState = {
-    data: data || { log: [], logfile: id, branches: {} },
+    data: data || { id, name: '', log: [], logfile: id, branches: {} },
     isGenerating: false,
     isConnected: false,
     pendingTool: null,
@@ -97,9 +97,11 @@ export async function initializeConversations(
   conversationIds.forEach((id) => {
     if (!conversations$.get(id)) {
       // Check if this is a demo conversation
-      const demoConv = demoConversations.find((conv: DemoConversation) => conv.name === id);
+      const demoConv = demoConversations.find((conv: DemoConversation) => conv.id === id);
       if (demoConv) {
         initConversation(id, {
+          id: demoConv.id,
+          name: demoConv.name,
           log: demoConv.messages,
           logfile: id,
           branches: {},
@@ -112,7 +114,7 @@ export async function initializeConversations(
 
   // Then load data for the first N non-demo conversations
   const toLoad = conversationIds
-    .filter((id) => !demoConversations.some((conv) => conv.name === id))
+    .filter((id) => !demoConversations.some((conv) => conv.id === id))
     .slice(0, limit);
 
   if (toLoad.length === 0) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -24,6 +24,8 @@ export interface SendMessageRequest extends Message {
 
 // Response from /api/conversations/<logfile>
 export interface ConversationResponse {
+  id: string;
+  name: string;
   log: (Message | StreamingMessage)[];
   logfile: string;
   branches: Record<string, Message[]>;
@@ -51,6 +53,7 @@ export interface McpConfig {
 
 export interface ChatConfig {
   chat: {
+    name: string | null;
     model: string | null;
     tools: string[] | null;
     tool_format: ToolFormat | null;

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -18,16 +18,10 @@ export interface ToolUse {
 }
 
 export interface ConversationSummary {
+  id: string;
   name: string;
   modified: number;
   messages: number;
-  branch?: string;
-}
-
-export interface ConversationDetails {
-  name: string;
-  modified: number;
-  messages: Message[];
   branch?: string;
 }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -5,7 +5,7 @@ import type {
   CreateConversationRequest,
   SendMessageRequest,
 } from '@/types/api';
-import type { Message, ToolUse } from '@/types/conversation';
+import type { ConversationSummary, Message, ToolUse } from '@/types/conversation';
 import { type Observable } from '@legendapp/state';
 import { observable } from '@legendapp/state';
 
@@ -450,14 +450,12 @@ export class ApiClient {
     }
   }
 
-  async getConversations(
-    limit: number = 100
-  ): Promise<{ name: string; modified: number; messages: number }[]> {
+  async getConversations(limit: number = 100): Promise<ConversationSummary[]> {
     if (!this.isConnected) {
       throw new ApiClientError('Not connected to API');
     }
     try {
-      return await this.fetchJson<{ name: string; modified: number; messages: number }[]>(
+      return await this.fetchJson<ConversationSummary[]>(
         `${this.baseUrl}/api/v2/conversations?limit=${limit}`
       );
     } catch (error) {

--- a/src/utils/conversation.ts
+++ b/src/utils/conversation.ts
@@ -6,6 +6,7 @@ import type { ConversationItem } from '@/components/ConversationList';
  */
 export function toConversationItem(conv: ConversationSummary): ConversationItem {
   return {
+    id: conv.id,
     name: conv.name,
     lastUpdated: new Date(conv.modified * 1000), // Convert Unix timestamp to Date
     messageCount: conv.messages,


### PR DESCRIPTION
Depends on https://github.com/gptme/gptme/pull/549
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for conversation display names by separating ID and name fields across components and API interactions.
> 
>   - **Behavior**:
>     - Adds `id` field to `ConversationItem` and `DemoConversation` interfaces in `ConversationList.tsx` and `democonversations.ts`.
>     - Updates logic in `ConversationList.tsx` to use `id` instead of `name` for identifying conversations.
>     - Modifies `Conversations.tsx` to initialize and handle conversations using `id`.
>     - Updates `useConversation.ts` to load and connect conversations using `id`.
>     - Changes `selectedConversation$` initialization to use `id` in `conversations.ts`.
>   - **API**:
>     - Updates `ConversationResponse` and `ConversationSummary` interfaces in `api.ts` and `conversation.ts` to include `id`.
>     - Modifies `ApiClient` methods in `api.ts` to handle conversations by `id`.
>   - **Utils**:
>     - Updates `toConversationItem` and `toConversationItems` in `conversation.ts` to map `id` and `name` correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 64e4682d9186794255ba6585cf7de2c6f287c051. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->