### PR TITLE
Fix model selector issues in ChatInput and ConversationSettings

### DIFF
--- a/src/components/ConversationContent.tsx
+++ b/src/components/ConversationContent.tsx
@@ -10,21 +10,12 @@ import { InlineToolExecution } from './InlineToolExecution';
 import { For, Memo, useObservable, useObserveEffect } from '@legendapp/state/react';
 import { getObservableIndex } from '@legendapp/state';
 import { useApi } from '@/contexts/ApiContext';
+import { useModels } from '@/hooks/useModels';
 
 interface Props {
   conversationId: string;
   isReadOnly?: boolean;
 }
-
-// This can be replaced with an API call to fetch available models from the server
-export const AVAILABLE_MODELS = [
-  'anthropic/claude-3-5-sonnet-20240620',
-  'anthropic/claude-3-opus-20240229',
-  'anthropic/claude-3-sonnet-20240229',
-  'anthropic/claude-3-haiku-20240307',
-  'openai/gpt-4o',
-  'openai/gpt-4o-mini',
-];
 
 export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) => {
   const { conversation$, sendMessage, confirmTool, interruptGeneration } =
@@ -36,6 +27,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
 
   const { api } = useApi();
   const hasSession$ = useObservable<boolean>(false);
+  const { defaultModel } = useModels();
 
   useObserveEffect(api.sessions$.get(conversationId), () => {
     if (!isReadOnly) {
@@ -257,7 +249,7 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
           onInterrupt={interruptGeneration}
           isReadOnly={isReadOnly}
           hasSession$={hasSession$}
-          defaultModel={AVAILABLE_MODELS[0]}
+          defaultModel={defaultModel || undefined}
           autoFocus$={shouldFocus$}
         />
       </div>

--- a/src/components/ConversationSettings.tsx
+++ b/src/components/ConversationSettings.tsx
@@ -1,7 +1,7 @@
 import { useState, type FC } from 'react';
 import { DeleteConversationConfirmationDialog } from './DeleteConversationConfirmationDialog';
 import { Trash, Loader2 } from 'lucide-react';
-import { AVAILABLE_MODELS } from './ConversationContent';
+import { ModelSelector } from './ModelSelector';
 import {
   Form,
   FormField,
@@ -11,13 +11,6 @@ import {
   FormDescription,
   FormMessage,
 } from '@/components/ui/form';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
@@ -32,7 +25,7 @@ interface ConversationSettingsProps {
 
 export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversationId }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const { form, toolFields, envFields, serverFields, onSubmit, chatConfig } =
+  const { form, toolFields, envFields, serverFields, onSubmit } =
     useConversationSettings(conversationId);
 
   const {
@@ -43,186 +36,158 @@ export const ConversationSettings: FC<ConversationSettingsProps> = ({ conversati
 
   return (
     <div className="flex flex-col">
-      {chatConfig && (
-        <Form {...form}>
-          <form onSubmit={handleSubmit(onSubmit)} className="flex h-full flex-col">
-            <div className="flex-1 space-y-8 overflow-y-auto p-4 pb-24">
-              <h3 className="mt-4 text-lg font-medium">Chat Settings</h3>
+      <Form {...form}>
+        <form onSubmit={handleSubmit(onSubmit)} className="flex h-full flex-col">
+          <div className="flex-1 space-y-8 overflow-y-auto p-4 pb-24">
+            <h3 className="mt-4 text-lg font-medium">Chat Settings</h3>
 
-              {/* Model Field */}
-              <FormField
-                control={control}
-                name="chat.model"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Model</FormLabel>
-                    <Select
-                      onValueChange={field.onChange}
-                      value={field.value ?? ''}
+            {/* Model Field */}
+            <ModelSelector
+              control={control}
+              name="chat.model"
+              disabled={isSubmitting}
+              placeholder="Select a model"
+            />
+
+            {/* Workspace Field */}
+            <FormField
+              control={control}
+              name="chat.workspace"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Workspace Directory</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="e.g., /path/to/project or ."
+                      {...field}
+                      value={field.value || ''}
                       disabled={isSubmitting}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select a model" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {AVAILABLE_MODELS.map((model) => (
-                          <SelectItem key={model} value={model}>
-                            {model}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    The directory on the server where the agent can read/write files. Use '.' for
+                    the default.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-              {/* Workspace Field */}
+            {/* Environment Variables */}
+            <EnvironmentVariables
+              form={form}
+              fieldArray={envFields}
+              isSubmitting={isSubmitting}
+              description="Environment variables available to the agent and tools."
+            />
+
+            {/* Tools Configuration */}
+            <ToolsConfiguration form={form} toolFields={toolFields} isSubmitting={isSubmitting} />
+
+            {/* MCP Configuration */}
+            <McpConfiguration form={form} serverFields={serverFields} isSubmitting={isSubmitting} />
+
+            {/* Advanced/rare toggles */}
+            <h3 className="text-lg font-medium">Advanced Settings</h3>
+            <div className="space-y-2 rounded-lg border px-3 py-2 shadow-sm">
+              {/* Stream Field */}
               <FormField
                 control={control}
-                name="chat.workspace"
+                name="chat.stream"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Workspace Directory</FormLabel>
+                  <FormItem className="flex flex-row items-center justify-between">
+                    <div className="space-y-0.5">
+                      <FormLabel>Stream Response</FormLabel>
+                    </div>
                     <FormControl>
-                      <Input
-                        placeholder="e.g., /path/to/project or ."
-                        {...field}
-                        value={field.value || ''}
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
                         disabled={isSubmitting}
                       />
                     </FormControl>
-                    <FormDescription>
-                      The directory on the server where the agent can read/write files. Use '.' for
-                      the default.
-                    </FormDescription>
-                    <FormMessage />
                   </FormItem>
                 )}
               />
 
-              {/* Environment Variables */}
-              <EnvironmentVariables
-                form={form}
-                fieldArray={envFields}
-                isSubmitting={isSubmitting}
-                description="Environment variables available to the agent and tools."
-              />
-
-              {/* Tools Configuration */}
-              <ToolsConfiguration form={form} toolFields={toolFields} isSubmitting={isSubmitting} />
-
-              {/* MCP Configuration */}
-              <McpConfiguration
-                form={form}
-                serverFields={serverFields}
-                isSubmitting={isSubmitting}
-              />
-
-              {/* Advanced/rare toggles */}
-              <h3 className="text-lg font-medium">Advanced Settings</h3>
-              <div className="space-y-2 rounded-lg border px-3 py-2 shadow-sm">
-                {/* Stream Field */}
-                <FormField
-                  control={control}
-                  name="chat.stream"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-row items-center justify-between">
-                      <div className="space-y-0.5">
-                        <FormLabel>Stream Response</FormLabel>
-                      </div>
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                          disabled={isSubmitting}
-                        />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-
-                {/* Interactive Field */}
-                <FormField
-                  control={control}
-                  name="chat.interactive"
-                  render={({ field }) => (
-                    <FormItem className="flex flex-row items-center justify-between">
-                      <div className="space-y-0.5">
-                        <FormLabel>Interactive Mode</FormLabel>
-                      </div>
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                          disabled={isSubmitting}
-                        />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              {/* Danger Zone */}
-              <div className="mt-8 space-y-6">
-                <h3 className="text-lg font-medium text-destructive">Danger Zone</h3>
-                <div className="rounded-lg border-2 border-destructive/20 p-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h4 className="font-medium">Delete Conversation</h4>
-                      <p className="text-sm text-muted-foreground">
-                        Permanently delete this conversation and all its messages.
-                      </p>
+              {/* Interactive Field */}
+              <FormField
+                control={control}
+                name="chat.interactive"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between">
+                    <div className="space-y-0.5">
+                      <FormLabel>Interactive Mode</FormLabel>
                     </div>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => setDeleteDialogOpen(true)}
-                      className="shrink-0"
-                    >
-                      <Trash className="mr-2 h-4 w-4" />
-                      Delete
-                    </Button>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Danger Zone */}
+            <div className="mt-8 space-y-6">
+              <h3 className="text-lg font-medium text-destructive">Danger Zone</h3>
+              <div className="rounded-lg border-2 border-destructive/20 p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h4 className="font-medium">Delete Conversation</h4>
+                    <p className="text-sm text-muted-foreground">
+                      Permanently delete this conversation and all its messages.
+                    </p>
                   </div>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setDeleteDialogOpen(true)}
+                    className="shrink-0"
+                  >
+                    <Trash className="mr-2 h-4 w-4" />
+                    Delete
+                  </Button>
                 </div>
               </div>
             </div>
+          </div>
 
-            {/* Submit Button */}
-            <div className="sticky bottom-0 mt-auto border-t bg-background p-4">
-              <Button
-                type="submit"
-                disabled={!isDirty || isSubmitting}
-                variant={isDirty ? 'default' : 'secondary'}
-                className="w-full"
-              >
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Saving...
-                  </>
-                ) : isDirty ? (
-                  'Save Changes'
-                ) : (
-                  'Everything saved'
-                )}
-              </Button>
-            </div>
+          {/* Submit Button */}
+          <div className="sticky bottom-0 mt-auto border-t bg-background p-4">
+            <Button
+              type="submit"
+              disabled={!isDirty || isSubmitting}
+              variant={isDirty ? 'default' : 'secondary'}
+              className="w-full"
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Saving...
+                </>
+              ) : isDirty ? (
+                'Save Changes'
+              ) : (
+                'Everything saved'
+              )}
+            </Button>
+          </div>
 
-            {/* Delete Dialog */}
-            <DeleteConversationConfirmationDialog
-              conversationName={conversationId}
-              open={deleteDialogOpen}
-              onOpenChange={setDeleteDialogOpen}
-              onDelete={() => {
-                window.location.href = '/';
-              }}
-            />
-          </form>
-        </Form>
-      )}
+          {/* Delete Dialog */}
+          <DeleteConversationConfirmationDialog
+            conversationName={conversationId}
+            open={deleteDialogOpen}
+            onOpenChange={setDeleteDialogOpen}
+            onDelete={() => {
+              window.location.href = '/';
+            }}
+          />
+        </form>
+      </Form>
     </div>
   );
 };

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -1,0 +1,109 @@
+import { Loader2 } from 'lucide-react';
+import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ProviderIcon } from '@/components/ProviderIcon';
+import { useModels } from '@/hooks/useModels';
+import type { Control, FieldPath, FieldValues } from 'react-hook-form';
+
+interface ModelSelectorProps<T extends FieldValues> {
+  control?: Control<T>;
+  name?: FieldPath<T>;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  label?: string;
+  showFormField?: boolean;
+}
+
+export function ModelSelector<T extends FieldValues = FieldValues>({
+  control,
+  name,
+  value,
+  onValueChange,
+  disabled = false,
+  placeholder,
+  label = 'Model',
+  showFormField = true,
+}: ModelSelectorProps<T>) {
+  const { models, availableModels, isLoading } = useModels();
+
+  const renderModelItem = (modelFull: string) => {
+    const modelInfo = models.find((m) => m.id === modelFull);
+    return (
+      <div className="flex flex-col">
+        <div className="flex items-center gap-2">
+          {modelInfo?.provider && <ProviderIcon provider={modelInfo.provider} />}
+          <span className="font-medium">{modelInfo?.model || modelFull}</span>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {modelInfo?.context && <span>{Math.round(modelInfo.context / 1000)}k ctx</span>}
+          {modelInfo?.supports_vision && <span className="text-blue-600">👁️ vision</span>}
+          {modelInfo?.supports_reasoning && <span className="text-green-600">🧠 reasoning</span>}
+        </div>
+      </div>
+    );
+  };
+
+  const selectContent = (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled || isLoading}>
+      <SelectTrigger>
+        <div className="flex w-full items-center justify-between">
+          <SelectValue placeholder={placeholder || 'Select model'} />
+          {isLoading && <Loader2 className="h-4 w-4 flex-shrink-0 animate-spin" />}
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        {availableModels.map((modelFull) => (
+          <SelectItem key={modelFull} value={modelFull}>
+            {renderModelItem(modelFull)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
+  if (!showFormField || !control || !name) {
+    return selectContent;
+  }
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <Select
+              onValueChange={field.onChange}
+              value={field.value ?? ''}
+              disabled={disabled || isLoading}
+            >
+              <SelectTrigger>
+                <div className="flex w-full items-center justify-between">
+                  <SelectValue placeholder={placeholder || 'Select model'} />
+                  {isLoading && <Loader2 className="h-4 w-4 flex-shrink-0 animate-spin" />}
+                </div>
+              </SelectTrigger>
+              <SelectContent>
+                {availableModels.map((modelFull) => (
+                  <SelectItem key={modelFull} value={modelFull}>
+                    {renderModelItem(modelFull)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -66,7 +66,19 @@ export function useConversation(conversationId: string) {
 
         // Load conversation data from API
         const data = await api.getConversation(conversationId);
-        updateConversation(conversationId, { data });
+
+        // Also load the chat config
+        try {
+          const chatConfig = await api.getChatConfig(conversationId);
+          updateConversation(conversationId, { data, chatConfig });
+        } catch (error) {
+          console.warn(
+            `[useConversation] Failed to load chat config for ${conversationId}:`,
+            error
+          );
+          // Still update with conversation data even if config fails
+          updateConversation(conversationId, { data });
+        }
 
         // Check number of connected conversations
         const connectedConvs = Array.from(conversations$.get().entries())

--- a/src/hooks/useConversationSettings.ts
+++ b/src/hooks/useConversationSettings.ts
@@ -8,6 +8,30 @@ import type { ChatConfig } from '@/types/api';
 import { useEffect } from 'react';
 import { ToolFormat } from '@/types/api';
 
+const chatConfigToFormValues = (config: ChatConfig | null): FormSchema => ({
+  chat: {
+    model: config?.chat.model || '',
+    tools: config?.chat.tools?.map((tool) => ({ name: tool })) || [],
+    tool_format: config?.chat.tool_format || ToolFormat.MARKDOWN,
+    stream: config?.chat.stream ?? true,
+    interactive: config?.chat.interactive ?? false,
+    workspace: config?.chat.workspace || '',
+    env: config?.env ? Object.entries(config.env).map(([key, value]) => ({ key, value })) : [],
+  },
+  mcp: {
+    enabled: config?.mcp?.enabled ?? false,
+    auto_start: config?.mcp?.auto_start ?? false,
+    servers:
+      config?.mcp?.servers?.map((server) => ({
+        name: server.name || '',
+        enabled: server.enabled ?? false,
+        command: server.command || '',
+        args: server.args?.join(', ') || '',
+        env: server.env ? Object.entries(server.env).map(([key, value]) => ({ key, value })) : [],
+      })) || [],
+  },
+});
+
 export const useConversationSettings = (conversationId: string) => {
   const api = useApi();
   const conversation$ = conversations$.get(conversationId);
@@ -15,22 +39,7 @@ export const useConversationSettings = (conversationId: string) => {
 
   const form = useForm<FormSchema>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
-      chat: {
-        model: '',
-        tools: [],
-        tool_format: ToolFormat.MARKDOWN,
-        stream: true,
-        interactive: false,
-        workspace: '',
-        env: [],
-      },
-      mcp: {
-        enabled: false,
-        auto_start: false,
-        servers: [],
-      },
-    },
+    defaultValues: chatConfigToFormValues(chatConfig),
   });
 
   const toolFields = useFieldArray({
@@ -48,39 +57,11 @@ export const useConversationSettings = (conversationId: string) => {
     name: 'mcp.servers',
   });
 
-  // Reset form when chatConfig loads or changes
+  // Reset form when chatConfig loads or changes, or when conversation changes
+  // Note: We intentionally exclude 'form' from dependencies to prevent multiple resets
   useEffect(() => {
-    if (chatConfig) {
-      console.log('Resetting form with chatConfig:', chatConfig);
-      form.reset({
-        chat: {
-          model: chatConfig.chat.model || '',
-          tools: chatConfig.chat.tools?.map((tool) => ({ name: tool })) || [],
-          tool_format: chatConfig.chat.tool_format || ToolFormat.MARKDOWN,
-          stream: chatConfig.chat.stream ?? true,
-          interactive: chatConfig.chat.interactive ?? false,
-          workspace: chatConfig.chat.workspace || '',
-          env: chatConfig.env
-            ? Object.entries(chatConfig.env).map(([key, value]) => ({ key, value }))
-            : [],
-        },
-        mcp: {
-          enabled: chatConfig.mcp?.enabled ?? false,
-          auto_start: chatConfig.mcp?.auto_start ?? false,
-          servers:
-            chatConfig.mcp?.servers?.map((server) => ({
-              name: server.name || '',
-              enabled: server.enabled ?? false,
-              command: server.command || '',
-              args: server.args?.join(', ') || '',
-              env: server.env
-                ? Object.entries(server.env).map(([key, value]) => ({ key, value }))
-                : [],
-            })) || [],
-        },
-      });
-    }
-  }, [chatConfig, form]);
+    form.reset(chatConfigToFormValues(chatConfig));
+  }, [chatConfig, conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load the chat config if it's not already loaded
   useEffect(() => {

--- a/src/hooks/useModels.ts
+++ b/src/hooks/useModels.ts
@@ -20,6 +20,7 @@ export interface ModelsResponse {
 }
 
 const fallbackModels = [
+  'anthropic/claude-sonnet-4-20250514',
   'anthropic/claude-3-5-sonnet-20240620',
   'anthropic/claude-3-opus-20240229',
   'anthropic/claude-3-sonnet-20240229',


### PR DESCRIPTION
## Problem
When loading existing conversations, both ChatInput and ConversationSettings would show 'Select a model' instead of displaying the conversation's actual model. Additionally, switching between conversations didn't properly update the settings panel.

## Root Causes
1. **Conditional rendering**: ConversationSettings used conditional rendering based on , causing form components to mount/unmount and disrupting value flow
2. **Missing config loading**: ChatInput didn't read from conversation config, only used global defaults
3. **Form state issues**: Form initialization and reset logic had timing problems
4. **Code duplication**: Multiple hardcoded model lists throughout the app

## Solution
- ✅ Create reusable ModelSelector component with both form and standalone support
- ✅ Remove conditional rendering that caused timing issues
- ✅ Add chat config loading to useConversation hook
- ✅ Implement dynamic form initialization with proper reset logic
- ✅ Add chatConfigToFormValues helper to eliminate duplication
- ✅ Replace hardcoded AVAILABLE_MODELS with dynamic fetching
- ✅ Add loading indicators and model capability display

## Testing
- [x] ChatInput shows correct model for existing conversations
- [x] ConversationSettings displays actual model instead of placeholder
- [x] Form shows 'Everything saved' when values match config
- [x] Panel updates correctly when switching conversations
- [x] Loading states work properly during model fetching

Fixes the model selector displaying 'Select a model' instead of the actual conversation model.