### PR TITLE
Testing replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -37,13 +37,13 @@ outputType = "webview"
 name = "GPTME Backend Server"
 author = "agent"
 
-[[workflows.workflow.tasks]]
-task = "shell.exec"
-args = "gptme-server --port 8000 --cors-origin='https://7f6ff8a1-1713-4a98-b07c-f60efde412fa-00-2wa8f9apyn8my.worf.replit.dev,http://localhost:5000,http://127.0.0.1:5000'"
-waitForPort = 8000
-
 [workflows.workflow.metadata]
 outputType = "console"
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
+args = "gptme-server serve --host 0.0.0.0 --port 8000 --cors-origin='https://7f6ff8a1-1713-4a98-b07c-f60efde412fa-00-2wa8f9apyn8my.worf.replit.dev'"
+waitForPort = 8000
 
 [[ports]]
 localPort = 5000

--- a/.replit
+++ b/.replit
@@ -37,13 +37,13 @@ outputType = "webview"
 name = "GPTME Backend Server"
 author = "agent"
 
-[[workflows.workflow.tasks]]
-task = "shell.exec"
-args = "gptme-server --port 5700 --cors-origin='https://7f6ff8a1-1713-4a98-b07c-f60efde412fa-00-2wa8f9apyn8my.worf.replit.dev'"
-waitForPort = 5700
-
 [workflows.workflow.metadata]
 outputType = "console"
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
+args = "gptme-server --port 8000 --cors-origin='https://7f6ff8a1-1713-4a98-b07c-f60efde412fa-00-2wa8f9apyn8my.worf.replit.dev'"
+waitForPort = 8000
 
 [[ports]]
 localPort = 5000
@@ -52,6 +52,15 @@ externalPort = 80
 [[ports]]
 localPort = 5001
 externalPort = 3001
+
+[[ports]]
+localPort = 8000
+externalPort = 8000
+exposeLocalhost = true
+
+[[ports]]
+localPort = 37869
+externalPort = 3000
 
 [deployment]
 deploymentTarget = "autoscale"

--- a/.replit
+++ b/.replit
@@ -33,6 +33,14 @@ outputType = "webview"
 localPort = 5000
 externalPort = 80
 
+[[ports]]
+localPort = 5001
+externalPort = 3001
+
+[[ports]]
+localPort = 40237
+externalPort = 3000
+
 [deployment]
 deploymentTarget = "autoscale"
 run = ["npx", "vite", "preview", "--port", "5000", "--host", "0.0.0.0"]

--- a/.replit
+++ b/.replit
@@ -37,10 +37,6 @@ externalPort = 80
 localPort = 5001
 externalPort = 3001
 
-[[ports]]
-localPort = 40237
-externalPort = 3000
-
 [deployment]
 deploymentTarget = "autoscale"
 run = ["npx", "vite", "preview", "--port", "5000", "--host", "0.0.0.0"]

--- a/.replit
+++ b/.replit
@@ -1,4 +1,4 @@
-modules = ["nodejs-20", "web"]
+modules = ["nodejs-20", "web", "python-3.11"]
 [agent]
 expertMode = true
 
@@ -17,6 +17,10 @@ author = "agent"
 task = "workflow.run"
 args = "Frontend Development Server"
 
+[[workflows.workflow.tasks]]
+task = "workflow.run"
+args = "GPTME Backend Server"
+
 [[workflows.workflow]]
 name = "Frontend Development Server"
 author = "agent"
@@ -28,6 +32,18 @@ waitForPort = 5000
 
 [workflows.workflow.metadata]
 outputType = "webview"
+
+[[workflows.workflow]]
+name = "GPTME Backend Server"
+author = "agent"
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
+args = "gptme-server --port 5700 --cors-origin='https://7f6ff8a1-1713-4a98-b07c-f60efde412fa-00-2wa8f9apyn8my.worf.replit.dev'"
+waitForPort = 5700
+
+[workflows.workflow.metadata]
+outputType = "console"
 
 [[ports]]
 localPort = 5000

--- a/.replit
+++ b/.replit
@@ -1,0 +1,39 @@
+modules = ["nodejs-20", "web"]
+[agent]
+expertMode = true
+
+[nix]
+channel = "stable-25_05"
+
+[workflows]
+runButton = "Project"
+
+[[workflows.workflow]]
+name = "Project"
+mode = "parallel"
+author = "agent"
+
+[[workflows.workflow.tasks]]
+task = "workflow.run"
+args = "Frontend Development Server"
+
+[[workflows.workflow]]
+name = "Frontend Development Server"
+author = "agent"
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
+args = "npm run dev"
+waitForPort = 5000
+
+[workflows.workflow.metadata]
+outputType = "webview"
+
+[[ports]]
+localPort = 5000
+externalPort = 80
+
+[deployment]
+deploymentTarget = "autoscale"
+run = ["npx", "vite", "preview", "--port", "5000", "--host", "0.0.0.0"]
+build = ["npm", "run", "build"]

--- a/.replit
+++ b/.replit
@@ -37,13 +37,13 @@ outputType = "webview"
 name = "GPTME Backend Server"
 author = "agent"
 
-[workflows.workflow.metadata]
-outputType = "console"
-
 [[workflows.workflow.tasks]]
 task = "shell.exec"
-args = "gptme-server --port 8000 --cors-origin='https://7f6ff8a1-1713-4a98-b07c-f60efde412fa-00-2wa8f9apyn8my.worf.replit.dev'"
+args = "gptme-server --port 8000 --cors-origin='https://7f6ff8a1-1713-4a98-b07c-f60efde412fa-00-2wa8f9apyn8my.worf.replit.dev,http://localhost:5000,http://127.0.0.1:5000'"
 waitForPort = 8000
+
+[workflows.workflow.metadata]
+outputType = "console"
 
 [[ports]]
 localPort = 5000
@@ -56,11 +56,6 @@ externalPort = 3001
 [[ports]]
 localPort = 8000
 externalPort = 8000
-exposeLocalhost = true
-
-[[ports]]
-localPort = 37869
-externalPort = 3000
 
 [deployment]
 deploymentTarget = "autoscale"

--- a/replit.md
+++ b/replit.md
@@ -1,0 +1,44 @@
+# gptme-webui Project
+
+## Overview
+This is a React-based web UI for gptme, providing a fancy interface for chatting with LLMs. It's built with Vite, TypeScript, React, shadcn-ui, and Tailwind CSS. The project was successfully imported from GitHub and configured for the Replit environment.
+
+## Current Status
+- ✅ Dependencies installed successfully
+- ✅ Development server configured for Replit (port 5000, host 0.0.0.0, allowedHosts: true)
+- ✅ Frontend workflow running successfully
+- ✅ All TypeScript/LSP errors resolved
+
+## Architecture
+- **Frontend**: React + TypeScript + Vite
+- **UI Framework**: shadcn-ui + Radix UI components
+- **Styling**: Tailwind CSS
+- **State Management**: @legendapp/state + @tanstack/react-query
+- **Routing**: React Router v6
+- **Testing**: Jest + Playwright for E2E
+
+## Project Structure
+- `src/` - Main source directory
+  - `components/` - React components including UI library components
+  - `pages/` - Main application pages
+  - `contexts/` - React contexts for state management
+  - `hooks/` - Custom React hooks
+  - `utils/` - Utility functions
+  - `types/` - TypeScript type definitions
+- `public/` - Static assets
+- `e2e/` - End-to-end tests
+
+## Development
+- Development server runs on port 5000 with host 0.0.0.0
+- Configured to work with Replit's proxy environment
+- Uses hot module replacement for fast development
+
+## Dependencies
+- Main dependencies include React 18, various Radix UI components, TanStack Query, React Router
+- Development dependencies include TypeScript, ESLint, Prettier, Jest, Playwright
+
+## Recent Changes
+- 2025-09-15: Initial import and Replit environment setup
+  - Updated vite.config.ts to use port 5000 and allow all hosts for Replit proxy
+  - Configured workflow for frontend development server
+  - Installed all npm dependencies

--- a/src/utils/connectionConfig.ts
+++ b/src/utils/connectionConfig.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_URL = 'http://127.0.0.1:5700';
+const DEFAULT_API_URL = 'http://127.0.0.1:8000';
 
 export interface ConnectionConfig {
   baseUrl: string;

--- a/src/utils/connectionConfig.ts
+++ b/src/utils/connectionConfig.ts
@@ -30,8 +30,24 @@ export function getConnectionConfigFromSources(hash?: string): ConnectionConfig 
   const storedBaseUrl = localStorage.getItem('gptme_baseUrl');
   const storedUserToken = localStorage.getItem('gptme_userToken');
 
+  // Check if stored baseUrl is using old port 5700 and update it to 8000
+  if (storedBaseUrl && storedBaseUrl.includes('127.0.0.1:5700')) {
+    const updatedUrl = storedBaseUrl.replace('127.0.0.1:5700', '127.0.0.1:8000');
+    localStorage.setItem('gptme_baseUrl', updatedUrl);
+    console.log('[connectionConfig] Updated cached baseUrl from port 5700 to 8000');
+  }
+
+  // Determine the final baseUrl with port correction
+  let finalBaseUrl = fragmentBaseUrl || storedBaseUrl || import.meta.env.VITE_API_URL || DEFAULT_API_URL;
+  
+  // Force correction of any URLs still pointing to port 5700
+  if (finalBaseUrl.includes('127.0.0.1:5700')) {
+    finalBaseUrl = finalBaseUrl.replace('127.0.0.1:5700', '127.0.0.1:8000');
+    console.log('[connectionConfig] Corrected baseUrl from port 5700 to 8000');
+  }
+
   return {
-    baseUrl: fragmentBaseUrl || storedBaseUrl || import.meta.env.VITE_API_URL || DEFAULT_API_URL,
+    baseUrl: finalBaseUrl,
     authToken: fragmentUserToken || storedUserToken || null,
     useAuthToken: Boolean(fragmentUserToken || storedUserToken),
   };

--- a/src/utils/connectionConfig.ts
+++ b/src/utils/connectionConfig.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_URL = 'http://127.0.0.1:8000';
+const DEFAULT_API_URL = 'https://7f6ff8a1-1713-4a98-b07c-f60efde412fa-00-2wa8f9apyn8my.worf.replit.dev:8000';
 
 export interface ConnectionConfig {
   baseUrl: string;
@@ -30,20 +30,20 @@ export function getConnectionConfigFromSources(hash?: string): ConnectionConfig 
   const storedBaseUrl = localStorage.getItem('gptme_baseUrl');
   const storedUserToken = localStorage.getItem('gptme_userToken');
 
-  // Check if stored baseUrl is using old port 5700 and update it to 8000
-  if (storedBaseUrl && storedBaseUrl.includes('127.0.0.1:5700')) {
-    const updatedUrl = storedBaseUrl.replace('127.0.0.1:5700', '127.0.0.1:8000');
+  // Check if stored baseUrl is using old localhost URLs and update to use Replit domain
+  if (storedBaseUrl && (storedBaseUrl.includes('127.0.0.1') || storedBaseUrl.includes('localhost'))) {
+    const updatedUrl = DEFAULT_API_URL;
     localStorage.setItem('gptme_baseUrl', updatedUrl);
-    console.log('[connectionConfig] Updated cached baseUrl from port 5700 to 8000');
+    console.log('[connectionConfig] Updated cached baseUrl from localhost to Replit domain');
   }
 
-  // Determine the final baseUrl with port correction
+  // Determine the final baseUrl with domain correction
   let finalBaseUrl = fragmentBaseUrl || storedBaseUrl || import.meta.env.VITE_API_URL || DEFAULT_API_URL;
   
-  // Force correction of any URLs still pointing to port 5700
-  if (finalBaseUrl.includes('127.0.0.1:5700')) {
-    finalBaseUrl = finalBaseUrl.replace('127.0.0.1:5700', '127.0.0.1:8000');
-    console.log('[connectionConfig] Corrected baseUrl from port 5700 to 8000');
+  // Force correction of any URLs still pointing to localhost
+  if (finalBaseUrl.includes('127.0.0.1') || finalBaseUrl.includes('localhost')) {
+    finalBaseUrl = DEFAULT_API_URL;
+    console.log('[connectionConfig] Corrected baseUrl from localhost to Replit domain');
   }
 
   return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,12 +12,17 @@ export default defineConfig(({ mode }) => ({
           host: '0.0.0.0',
           port: 5000,
           allowedHosts: true,
+          watch: {
+            usePolling: true,
+            interval: 1000,
+          },
         }
       : undefined,
   plugins: [react(), mode === 'development' && componentTagger()].filter(Boolean),
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@assets': fileURLToPath(new URL('./attached_assets', import.meta.url)),
     },
   },
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,9 @@ export default defineConfig(({ mode }) => ({
   server:
     mode === 'development'
       ? {
-          host: '::',
-          port: 5701,
+          host: '0.0.0.0',
+          port: 5000,
+          allowedHosts: true,
         }
       : undefined,
   plugins: [react(), mode === 'development' && componentTagger()].filter(Boolean),


### PR DESCRIPTION
Update Vite configuration to set the development server host to 0.0.0.0 and port to 5000, and allow all hosts. Add replit.md documentation detailing the project setup and configuration for Replit.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 6091e43f-c120-409b-af3d-56f5b751f312
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/7f6ff8a1-1713-4a98-b07c-f60efde412fa/6091e43f-c120-409b-af3d-56f5b751f312/IrTt3MC