### PR TITLE
fix(api): await operations in createConversationWithPlaceholder to pr…

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -631,29 +631,19 @@ export class ApiClient {
       workspace: options?.workspace || '.',
     });
 
-    // Handle server-side creation and auto-step in background
-    this.createConversation(conversationId, [message], {
+    // Await server-side creation and auto-step to propagate errors properly
+    await this.createConversation(conversationId, [message], {
       chat: {
         model: options?.model,
         stream: options?.stream,
         workspace: options?.workspace || '.',
       },
-    })
-      .then(() => {
-        // Auto-trigger generation now that the conversation is ready
-        this.step(conversationId, options?.model, options?.stream).catch((stepError) => {
-          console.error(`[ApiClient] Auto-step failed for ${conversationId}:`, stepError);
-        });
-      })
-      .catch((error) => {
-        console.error(
-          `[ApiClient] Background conversation creation failed for ${conversationId}:`,
-          error
-        );
-        // The placeholder conversation remains functional even if server sync fails
-      });
+    });
+    
+    // Auto-trigger generation now that the conversation is ready
+    await this.step(conversationId, options?.model, options?.stream);
 
-    // Return ID immediately for navigation
+    // Return ID only after operations complete successfully
     return conversationId;
   }
 


### PR DESCRIPTION
…opagate errors

Changes createConversationWithPlaceholder from fire-and-forget pattern to awaiting operations, allowing errors to propagate to caller's try-catch.

Before: Operations ran in background promises (.then/.catch), errors
        only logged, never reaching UI error handling.

After: Operations awaited, errors naturally propagate to WelcomeView.tsx
       error handling, showing proper error messages to users.

Benefits:
- Error handling in WelcomeView.tsx now works correctly
- Users see specific error messages (duplicates, network, auth)
- Users won't navigate to failed conversations
- Simpler, more maintainable code

Fixes architectural issue identified by Greptile and Erik. Addresses gptme/gptme-webui#37
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `createConversationWithPlaceholder` in `api.ts` now awaits operations to propagate errors to the UI, improving error handling and user experience.
> 
>   - **Behavior**:
>     - `createConversationWithPlaceholder` in `api.ts` now awaits `createConversation` and `step` operations instead of using `.then/.catch`.
>     - Errors propagate to `WelcomeView.tsx`, allowing UI to handle errors like duplicates, network, and auth issues.
>   - **Benefits**:
>     - Users see specific error messages and won't navigate to failed conversations.
>     - Code is simpler and more maintainable.
>   - **Fixes**:
>     - Addresses architectural issue identified by Greptile and Erik.
>     - Fixes gptme/gptme-webui#37.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 345213734ac331d9399ae1604aa7d7020016f1f2. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->