### PR TITLE
feat(ui): add auto-accept all toggle for tool calls

### DIFF
--- a/src/components/InlineToolConfirmation.tsx
+++ b/src/components/InlineToolConfirmation.tsx
@@ -220,6 +220,10 @@ export function InlineToolConfirmation({
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="w-48">
+                        <DropdownMenuItem onClick={() => onAuto(999999)}>
+                          Auto-accept all
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
                         <DropdownMenuItem onClick={() => onAuto(5)}>
                           Auto-confirm 5x
                         </DropdownMenuItem>


### PR DESCRIPTION
## Summary

Add a toggle option in the tool confirmation dropdown that enables indefinitely auto-accepting all tool calls until manually disabled.

## Changes

- Add `autoAcceptAll` state to `ConversationState` in store
- Add toggle UI with Switch component in dropdown menu
- Display visual indicator when auto-accept is enabled (clickable to disable)
- Modify `useConversation` to auto-confirm tools when toggle is enabled

## Motivation

Currently gptme-webui supports auto-accepting tool calls with finite counts (5x, 10x, custom). This PR adds a toggle mode that auto-accepts indefinitely until the user explicitly turns it off, providing more flexibility for autonomous workflows.

## Testing

- [ ] Toggle can be enabled/disabled from dropdown menu
- [ ] Visual indicator shows when auto-accept is active
- [ ] Clicking the indicator disables auto-accept
- [ ] Tools are automatically confirmed when toggle is enabled
- [ ] Toggle state persists within a conversation session

Related: [SUDO-61](https://linear.app/superuserlabs/issue/SUDO-61)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds an `autoAcceptAll` toggle to enable indefinite auto-acceptance of tool calls, with UI and state management updates.
> 
>   - **Behavior**:
>     - Adds `autoAcceptAll` state to `ConversationState` to enable indefinite auto-acceptance of tool calls.
>     - Modifies `useConversation` to auto-confirm tools when `autoAcceptAll` is enabled.
>   - **UI Components**:
>     - Adds a toggle UI with `Switch` component in `InlineToolConfirmation` to enable/disable `autoAcceptAll`.
>     - Displays a visual indicator in `InlineToolConfirmation` when `autoAcceptAll` is active, which is clickable to disable.
>   - **State Management**:
>     - Adds `setAutoAcceptAll()` function in `conversations.ts` to toggle `autoAcceptAll` state.
>     - Updates `ConversationContent` to pass `autoAcceptAll` state and toggle handler to `InlineToolConfirmation`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 3067cb7fda8ab22d38d92f8b5a12f29012d6cae0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->