### PR TITLE
fix: handle Session ID 404 errors in tool confirmation retry

### DIFF
--- a/src/components/UnifiedSidebar.tsx
+++ b/src/components/UnifiedSidebar.tsx
@@ -1,4 +1,11 @@
-import { ChevronDown, ChevronRight, UserRoundPlusIcon, PenSquare, Plus, Filter } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  UserRoundPlusIcon,
+  PenSquare,
+  Plus,
+  Filter,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ConversationList } from './ConversationList';
 import { AgentsList } from './AgentsList';
@@ -138,7 +145,7 @@ export const UnifiedSidebar: FC<Props> = ({
     // Filter by target type
     let filtered = tasks;
     if (!selectedTargetTypes.has('all')) {
-      filtered = tasks.filter(task => selectedTargetTypes.has(task.target_type));
+      filtered = tasks.filter((task) => selectedTargetTypes.has(task.target_type));
     }
 
     // Sort by status
@@ -180,10 +187,10 @@ export const UnifiedSidebar: FC<Props> = ({
           <div className="flex items-center gap-2 bg-background p-2">
             <span className="ml-1 font-medium">Tasks</span>
             <div className="flex-1" />
-            <Button 
-              variant="ghost" 
-              size="icon" 
-              className="h-6 w-6" 
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
               onClick={() => setShowFilters(!showFilters)}
             >
               <Filter className="h-4 w-4" />
@@ -225,7 +232,11 @@ export const UnifiedSidebar: FC<Props> = ({
                         }
                       }}
                     >
-                      {type === 'all' ? 'All' : type === 'pr' ? 'PR' : type.charAt(0).toUpperCase() + type.slice(1)}
+                      {type === 'all'
+                        ? 'All'
+                        : type === 'pr'
+                          ? 'PR'
+                          : type.charAt(0).toUpperCase() + type.slice(1)}
                     </Button>
                   );
                 })}

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -4,7 +4,8 @@ import { CommandPalette } from '../CommandPalette';
 
 // Mock UI command components
 jest.mock('../ui/command', () => ({
-  CommandDialog: ({ children, open }: any) => open ? <div data-testid="command-dialog">{children}</div> : null,
+  CommandDialog: ({ children, open }: any) =>
+    open ? <div data-testid="command-dialog">{children}</div> : null,
   CommandInput: ({ placeholder, value, onValueChange }: any) => (
     <input
       data-testid="command-input"
@@ -22,11 +23,7 @@ jest.mock('../ui/command', () => ({
     </div>
   ),
   CommandItem: ({ children, onSelect, value }: any) => (
-    <div
-      data-testid="command-item"
-      data-value={value}
-      onClick={() => onSelect?.()}
-    >
+    <div data-testid="command-item" data-value={value} onClick={() => onSelect?.()}>
       {children}
     </div>
   ),

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -19,6 +19,7 @@ import {
 } from '@/stores/conversations';
 import { playChime } from '@/utils/audio';
 import { notifyGenerationComplete, notifyToolConfirmation } from '@/utils/notifications';
+import { ApiClientError } from '@/utils/api';
 
 const MAX_CONNECTED_CONVERSATIONS = 3;
 
@@ -384,11 +385,12 @@ export function useConversation(conversationId: string) {
 
         // Check if it's a 404 error (either "Tool not found" or "Session ID not found")
         // Session ID may not be available yet during initial SSE connection
+        // ApiClientError has status property, not in message string
         const is404Error =
-          error instanceof Error &&
+          ApiClientError.isApiError(error) &&
+          error.status === 404 &&
           (error.message.includes('Tool not found') ||
-            error.message.includes('Session ID not found')) &&
-          error.message.includes('404');
+            error.message.includes('Session ID not found'));
 
         if (is404Error && attempt < 3) {
           console.log(`Retrying tool confirmation in 500ms (attempt ${attempt + 1}/3)`);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -639,7 +639,7 @@ export class ApiClient {
         workspace: options?.workspace || '.',
       },
     });
-    
+
     // Auto-trigger generation now that the conversation is ready
     await this.step(conversationId, options?.model, options?.stream);
 


### PR DESCRIPTION
## Summary

Fixes the first shell execution failure by expanding the retry logic to also catch 'Session ID not found' 404 errors.

## Problem

The retry logic was only matching 'Tool not found' 404 errors, but the actual error thrown when the SSE session isn't yet established is:

```
Session ID not found for conversation
```

This race condition occurs when:
1. User opens a conversation
2. SSE connection starts
3. `tool_pending` event arrives before `connected` event  
4. `confirmTool` is called but `sessions$` map doesn't have the ID yet
5. 404 error is thrown with 'Session ID not found'

The existing retry mechanism (3 attempts, 500ms delay) was designed to handle exactly this scenario, but the error message matching was incorrect.

## Solution

Expanded the 404 error check to match both error messages:
- 'Tool not found' (original)
- 'Session ID not found' (new)

## Testing

This should be tested by:
1. Opening a conversation with a pending tool
2. Quickly clicking confirm before the 'connected' event completes
3. Verifying that the retry succeeds instead of failing immediately

Partially addresses #99
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expands retry logic in `useConversation.ts` to handle 'Session ID not found' 404 errors during tool confirmation.
> 
>   - **Behavior**:
>     - Expands retry logic in `confirmTool` in `useConversation.ts` to handle 'Session ID not found' 404 errors.
>     - Original retry logic only handled 'Tool not found' 404 errors.
>   - **Testing**:
>     - Test by opening a conversation and confirming a tool before the 'connected' event completes.
>     - Verify retry mechanism handles 'Session ID not found' errors successfully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for e08959b68c6b06bc0f26c05afbd249b15deff2c9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->