### PR TITLE
fix: move step() to useConversation to fix streaming race condition

### DIFF
--- a/src/stores/conversations.ts
+++ b/src/stores/conversations.ts
@@ -30,6 +30,9 @@ export interface ConversationState {
   showInitialSystem: boolean;
   // The chat config
   chatConfig: ChatConfig | null;
+  // Whether this conversation needs initial step after connecting
+  // Used to fix race condition where step() was called before event subscription
+  needsInitialStep: boolean;
 }
 
 // Central store for all conversations
@@ -50,6 +53,7 @@ export function updateConversation(id: string, update: Partial<ConversationState
       executingTool: null,
       showInitialSystem: false,
       chatConfig: null,
+      needsInitialStep: false,
     });
   }
   mergeIntoObservable(conversations$.get(id), update);
@@ -83,7 +87,7 @@ export function setExecutingTool(id: string, toolId: string | null, tooluse: Too
 }
 
 // Initialize a new conversation in the store
-export function initConversation(id: string, data?: ConversationResponse) {
+export function initConversation(id: string, data?: ConversationResponse, options?: { needsInitialStep?: boolean }) {
   const initial: ConversationState = {
     data: data || {
       id,
@@ -99,8 +103,13 @@ export function initConversation(id: string, data?: ConversationResponse) {
     executingTool: null,
     showInitialSystem: false,
     chatConfig: null,
+    needsInitialStep: options?.needsInitialStep ?? false,
   };
   conversations$.set(id, initial);
+}
+
+export function setNeedsInitialStep(id: string, needsInitialStep: boolean) {
+  updateConversation(id, { needsInitialStep });
 }
 
 // Update conversation data in the store


### PR DESCRIPTION
## Summary

Fixes the issue where the first response tokens were missed when starting a new conversation from the welcome view (#91).

## Root Cause

A timing race condition in the conversation creation flow:

1. `createConversationWithPlaceholder()` called `step()`
2. Tokens started streaming on the server
3. THEN `navigate()` was called
4. Chat page mounted and subscribed to events
5. First tokens were already missed

This explains why prod sometimes works (faster navigation/mounting) while local dev doesn't.

## The Fix

- Added `needsInitialStep` flag to conversation state in the store
- `createConversationWithPlaceholder` sets this flag instead of calling `step()`
- `useConversation`'s `onConnected` callback checks the flag and triggers `step()`
- This ensures we only call `step()` AFTER the event subscription is ready

## Changes

- `src/stores/conversations.ts`: Added `needsInitialStep` field and setter
- `src/utils/api.ts`: Removed `step()` call, set flag instead
- `src/hooks/useConversation.ts`: Added initial step trigger after connection

Fixes #91
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition by deferring `step()` call until after event subscription is ready using a `needsInitialStep` flag.
> 
>   - **Behavior**:
>     - Fixes race condition by deferring `step()` call until after event subscription is ready.
>     - Introduces `needsInitialStep` flag in conversation state to manage initial step triggering.
>   - **Changes**:
>     - `useConversation.ts`: Adds logic in `onConnected` to check `needsInitialStep` and trigger `step()`.
>     - `conversations.ts`: Adds `needsInitialStep` field and related functions.
>     - `api.ts`: Removes `step()` call from `createConversationWithPlaceholder`, sets `needsInitialStep` flag instead.
>   - **Misc**:
>     - Fixes issue #91.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 2067e6d08c318dfea751d09c1f7b9303bb3ecb8a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->