### PR TITLE
feat: enable auto-reconnect for web environments

### DIFF
--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -11,8 +11,6 @@ import type { QueryClient } from '@tanstack/react-query';
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { toast } from 'sonner';
 
-import { isTauriEnvironment } from '@/utils/tauri';
-
 interface ApiContextType {
   api: ApiClient;
   isConnecting$: Observable<boolean>;
@@ -298,24 +296,13 @@ export function ApiProvider({
 
     const attemptInitialConnection = async () => {
       console.log('[ApiContext] Attempting initial connection');
-
-      // In Tauri environment, use autoconnect for better UX
-      if (isTauriEnvironment()) {
-        console.log('[ApiContext] Tauri environment detected, starting auto-connect');
-        await autoConnect(true);
-      } else {
-        // In web environment, try once and let user manually connect if needed
-        try {
-          await connect();
-        } catch (error) {
-          console.error('Initial connection attempt failed:', error);
-          // Don't show toast for initial connection failure in web environment
-        }
-      }
+      // Use autoConnect for all environments - enables launching webui before server
+      // autoConnect will retry with exponential backoff until successful or max attempts reached
+      await autoConnect(true);
     };
 
     void attemptInitialConnection();
-  }, [connect, autoConnect]);
+  }, [autoConnect]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary

Enable auto-reconnect for web environments so the webui can be launched before the server is ready.

## Changes

- Remove environment check that limited autoConnect to Tauri only
- Enable autoConnect for all environments (web and desktop)
- Remove unused `isTauriEnvironment` import

## Behavior

When the webui loads and can't connect to the server, it will now:
1. Retry with exponential backoff (1s, 2s, 4s, 8s... up to 30s max)
2. Show a success toast when connection is finally established
3. Stop after 10 failed attempts with an error message

This improves UX for:
- Launching webui before starting the server
- Server restarts while webui is open
- Temporary network connectivity issues

## Testing

1. Start gptme-webui without the server running
2. Observe retry attempts in console
3. Start gptme server
4. Observe automatic connection and success toast

Closes #63
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enables auto-reconnect for web environments by using `autoConnect` for all environments with retry logic in `ApiContext.tsx`.
> 
>   - **Behavior**:
>     - Enables `autoConnect` for all environments in `ApiContext.tsx`, allowing webui to launch before server readiness.
>     - Implements retry logic with exponential backoff (1s, 2s, 4s, 8s... up to 30s max) and stops after 10 failed attempts.
>     - Shows success toast on connection and error message after max attempts.
>   - **Code Changes**:
>     - Removes `isTauriEnvironment` check and import from `ApiContext.tsx`.
>     - Updates `useEffect` to always use `autoConnect` for initial connection attempts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for e1e718870ee17b0e5647812341eefeaf90666497. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->