### PR TITLE
feat(auth): derive exchange URL from configuration

### DIFF
--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -41,9 +41,10 @@ interface ApiContextType {
 const ApiContext = createContext<ApiContextType | null>(null);
 
 // Check if hash contains auth code (sync check)
+// Note: exchangeUrl is derived from configuration, only code is needed in URL
 function hasAuthCodeInHash(hash: string): boolean {
   const params = new URLSearchParams(hash);
-  return Boolean(params.get('code') && params.get('exchangeUrl'));
+  return Boolean(params.get('code'));
 }
 
 // Initial sync config (may be incomplete if auth code present)


### PR DESCRIPTION
## Summary

Implements Option B from the auth code flow discussion (gptme/gptme-infra#130):

Instead of requiring `exchangeUrl` in the URL hash, the webui now derives it from the `VITE_FLEET_OPERATOR_URL` environment variable (defaults to `https://fleet.gptme.ai`).

## Changes

- Added `FLEET_OPERATOR_URL` constant derived from `VITE_FLEET_OPERATOR_URL` env var
- Modified `getAuthCodeParams()` to only require `code` (not `exchangeUrl`)
- Added `getExchangeUrl()` helper to construct the exchange endpoint URL
- Updated `hasAuthCodeInHash()` check to only look for `code`

## Benefits

- Simpler auth code URLs: `#code=xxx` instead of `#code=xxx&exchangeUrl=...`
- Frontend is configured to know which backend to exchange codes with
- Environment variable allows different backends per deployment

## Related

- gptme/gptme-infra#130 - Auth code flow implementation (generates these URLs)
- Discussion: Erik preferred Option B - frontend should know which backend to use

## Testing

- `npm run build` passes
- Auth code flow should work with PR #130 in gptme-infra
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies auth code flow by deriving exchange URL from `VITE_FLEET_OPERATOR_URL`, reducing URL parameters and enhancing configurability.
> 
>   - **Behavior**:
>     - `getAuthCodeParams()` in `connectionConfig.ts` now only requires `code`, not `exchangeUrl`.
>     - `hasAuthCodeInHash()` in `ApiContext.tsx` updated to only check for `code`.
>     - `getExchangeUrl()` added to `connectionConfig.ts` to derive exchange URL from `VITE_FLEET_OPERATOR_URL`.
>   - **Configuration**:
>     - `FLEET_OPERATOR_URL` constant in `connectionConfig.ts` derived from `VITE_FLEET_OPERATOR_URL` env var, defaulting to `https://fleet.gptme.ai`.
>   - **Benefits**:
>     - Simplifies auth code URLs to `#code=xxx`.
>     - Frontend pre-configured for backend exchange, allowing different backends per deployment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 3005aa37d30f62a9079c74955810a79abfa1eb1b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->