### PR TITLE
fix(auth): re-check hash at mount time for SPA navigation

### DIFF
--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -255,7 +255,12 @@ export function ApiProvider({
   // Handle auth code exchange on mount
   useEffect(() => {
     const handleAuthCodeExchange = async () => {
-      if (!needsAuthCodeExchange) {
+      // Re-check hash at mount time (not module load time) for SPA navigation
+      // The module-level initialHash may be empty if the module loaded before navigation
+      const currentHash = window.location.hash.substring(1);
+      const hasAuthCode = hasAuthCodeInHash(currentHash);
+
+      if (!hasAuthCode) {
         return;
       }
 
@@ -263,7 +268,7 @@ export function ApiProvider({
       setIsExchangingAuthCode(true);
 
       try {
-        const config = await processConnectionFromHash(initialHash);
+        const config = await processConnectionFromHash(currentHash);
         console.log('[ApiContext] Auth code exchange successful, updating config');
 
         // Update the config with exchanged values


### PR DESCRIPTION
## Problem

When using the auth code flow with SPA navigation, the webui would fail to exchange the auth code and fall back to the default API URL (`http://127.0.0.1:5700`), causing CSP errors.

### Root Cause

The `initialHash` variable was captured at **module load time** (line 51 in ApiContext.tsx):
```typescript
const initialHash = window.location.hash.substring(1);
const needsAuthCodeExchange = hasAuthCodeInHash(initialHash);
```

When the user:
1. Visits the landing page at `/` (no hash)
2. The module loads with empty `initialHash`
3. Clicks 'Connect' and navigates to `/chat#code=xxx`
4. The module is already loaded with `needsAuthCodeExchange = false`
5. The auth code exchange never triggers
6. Falls back to default `127.0.0.1:5700` which CSP blocks

## Solution

Re-check `window.location.hash` at **component mount time** in the useEffect, not at module load time:

```typescript
const currentHash = window.location.hash.substring(1);
const hasAuthCode = hasAuthCodeInHash(currentHash);

if (!hasAuthCode) {
  return;
}
// ... proceed with auth code exchange
```

This ensures the hash is captured after SPA navigation completes.

## Testing

1. Clear localStorage
2. Visit landing page
3. Click 'Connect' on an instance
4. Should navigate to `/chat#code=xxx` and successfully exchange the auth code
5. Should connect to the correct instance URL (not `127.0.0.1:5700`)

Co-authored-by: Lofty <builderlofty@gmail.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-checks `window.location.hash` at component mount time in `ApiContext.tsx` to ensure correct auth code exchange for SPA navigation, preventing fallback to default URL.
> 
>   - **Behavior**:
>     - Re-check `window.location.hash` at component mount time in `useEffect` in `ApiContext.tsx` to handle SPA navigation.
>     - Prevents fallback to default API URL `127.0.0.1:5700` by ensuring auth code exchange triggers correctly.
>   - **Functions**:
>     - Modify `handleAuthCodeExchange` in `ApiProvider` to use `currentHash` instead of `initialHash`.
>     - Update `processConnectionFromHash` call to use `currentHash`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for c72203ebe1bd89c411c855cba593686850e8b622. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->