### PR TITLE
fix(auth): re-check hash at mount time for SPA navigation

### DIFF
--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -295,8 +295,11 @@ export function ApiProvider({
 
   // Attempt initial connection (skip if auth code exchange is happening)
   useEffect(() => {
-    if (needsAuthCodeExchange) {
-      // Auth code exchange will handle connection
+    // Re-check hash at mount time (not module load time) for SPA navigation
+    // This mirrors the check in the auth code exchange effect above
+    const currentHash = window.location.hash.substring(1);
+    if (hasAuthCodeInHash(currentHash)) {
+      // Auth code exchange effect will handle connection
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes auth code exchange for SPA navigation by re-checking `window.location.hash` at component mount time instead of relying on the module-level `initialHash` captured at module load time.

## Problem

When a user navigates to a hash with an auth code after the module has already loaded (SPA navigation), the module-level `initialHash` constant is stale and doesn't contain the auth code. This caused the auth code exchange to fail silently.

## Changes

### Fix 1: Re-check hash in auth code exchange effect (c72203e)
- Moved hash check from module-load time to component mount time
- Now correctly captures auth codes present after SPA navigation

### Fix 2: Prevent race condition in auto-connect effect (ab85580)
- The second `useEffect` (auto-connect) was using the stale module-level `needsAuthCodeExchange` constant
- Changed to re-check `window.location.hash` at mount time
- Prevents both auth exchange and auto-connect from running simultaneously

## Testing

- Verified in local dev environment with gptme-infra stack
- Both effects now independently check for auth code presence at mount time

Supersedes #112 (couldn't push to that branch directly).

cc @patriklaurell
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes auth code exchange for SPA navigation by re-checking `window.location.hash` at component mount time in `ApiProvider`.
> 
>   - **Behavior**:
>     - Re-check `window.location.hash` at component mount time in `ApiProvider` to capture auth codes for SPA navigation.
>     - Prevents silent failures in auth code exchange by using `currentHash` instead of `initialHash`.
>   - **Effects**:
>     - Updates `useEffect` for auth code exchange to use `currentHash`.
>     - Updates `useEffect` for auto-connect to prevent race conditions by checking `currentHash`.
>   - **Testing**:
>     - Verified in local dev environment with gptme-infra stack.
>     - Both effects now independently check for auth code presence at mount time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for ab85580528c3e4c06d7b99e9bd7dbbf377367dbe. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->