### PR TITLE
ci: skip e2e tests when API key unavailable (fork PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,26 +37,36 @@ jobs:
     - name: Build
       run: npm run build
 
+    # E2E tests require API key (not available on fork PRs due to GitHub security)
     - name: Start gptme-server in background
+      id: start-server
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       run: |
-        # pipx install gptme[server]
+        if [ -z "$ANTHROPIC_API_KEY" ]; then
+          echo "⚠️ No API key available (fork PR), skipping e2e tests"
+          echo "server_started=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
         pipx install "gptme[server] @ git+https://github.com/gptme/gptme.git"
-        gptme-server --cors-origin="http://localhost:5701" &  # run in background
-        sleep 3  # sleep so we get initial logs
+        gptme-server --cors-origin="http://localhost:5701" &
+        sleep 3
+        echo "server_started=true" >> $GITHUB_OUTPUT
 
     - name: Install Playwright browsers
+      if: steps.start-server.outputs.server_started == 'true'
       run: npx playwright install --with-deps chromium
 
     - name: Check that server is up
+      if: steps.start-server.outputs.server_started == 'true'
       run: curl --retry 2 --retry-delay 5 --retry-connrefused -sSfL http://localhost:5700/api
 
     - name: Run e2e tests
+      if: steps.start-server.outputs.server_started == 'true'
       run: npm run test:e2e
 
     - name: Upload test results
-      if: always()
+      if: always() && steps.start-server.outputs.server_started == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: playwright-report


### PR DESCRIPTION
## Summary

Fixes the CI failure affecting all fork PRs and some master pushes.

## Problem

Fork PRs don't have access to repository secrets due to GitHub's security model. This causes `gptme-server` to fail to start with:
```
No API keys set, no provider available.
ValueError: No API key found, couldn't auto-detect provider
```

This breaks all e2e tests, causing CI to fail even when the actual code changes are correct.

## Solution

Add conditional logic to gracefully skip e2e tests when no API key is available:

1. Server startup step checks for `ANTHROPIC_API_KEY`
2. If missing, sets `server_started=false` output and exits cleanly
3. Subsequent e2e-related steps check this output and skip if server not started

## What still runs on fork PRs
- ✅ Type checking
- ✅ Linting  
- ✅ Unit tests
- ✅ Build

## What runs only with secrets (maintainer PRs, master)
- ✅ Playwright browser installation
- ✅ Server startup
- ✅ E2E tests
- ✅ Test artifact upload

Fixes the issue mentioned in PR #113.

cc @patriklaurell
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds logic to `ci.yml` to skip e2e tests when API key is unavailable, fixing CI failures for fork PRs.
> 
>   - **Behavior**:
>     - Adds conditional logic in `ci.yml` to skip e2e tests if `ANTHROPIC_API_KEY` is unavailable.
>     - Server startup step sets `server_started=false` if API key is missing, exiting cleanly.
>     - E2E-related steps check `server_started` output and skip if false.
>   - **CI Workflow**:
>     - Type checking, linting, unit tests, and build run on all PRs.
>     - Playwright installation, server startup, e2e tests, and artifact upload run only if API key is available.
>   - **Misc**:
>     - Fixes CI failure for fork PRs and some master pushes due to missing API keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 4138e65ab2b65510edc66be4a1b92804a54b99d9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->