### PR TITLE
feat: hide messages with hide=true (auto-included lessons)

### DIFF
--- a/src/components/ConversationContent.tsx
+++ b/src/components/ConversationContent.tsx
@@ -210,6 +210,11 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
               return <div key={`${index}-${msg$.timestamp.get()}`} />;
             }
 
+            // Hide messages with hide=true (e.g., auto-included lessons)
+            if (msg$.hide?.get()) {
+              return <div key={`${index}-${msg$.timestamp.get()}`} />;
+            }
+
             // Get the previous and next messages for spacing context
             const previousMessage$ = index > 0 ? conversation$.data.log[index - 1] : undefined;
             const nextMessage$ = conversation$.data.log[index + 1];

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -5,6 +5,7 @@ export interface Message {
   content: string;
   timestamp?: string;
   files?: string[];
+  hide?: boolean;
 }
 
 export interface StreamingMessage extends Message {


### PR DESCRIPTION
This PR adds support for hiding messages with the `hide` attribute set to true.

This respects the `Message.hide` attribute from the gptme API, which is used for auto-included lessons.

## Changes
- Added `hide?: boolean` to the `Message` interface
- Filter out hidden messages in `ConversationContent` component

Fixes: https://linear.app/superuserlabs/issue/SUDO-39