### PR TITLE
ci: skip e2e tests when API keys unavailable (fork PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,20 @@ jobs:
     - name: Build
       run: npm run build
 
+    # E2E tests require API keys which aren't available for fork PRs
+    # See: https://github.com/gptme/gptme-webui/issues/119
+    - name: Check if API keys available for e2e tests
+      id: secrets-check
+      run: |
+        if [ -n "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
+          echo "available=true" >> $GITHUB_OUTPUT
+        else
+          echo "available=false" >> $GITHUB_OUTPUT
+          echo "::notice::Skipping e2e tests - API keys not available (likely a fork PR)"
+        fi
+
     - name: Start gptme-server in background
+      if: steps.secrets-check.outputs.available == 'true'
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       run: |
@@ -47,16 +60,19 @@ jobs:
         sleep 3  # sleep so we get initial logs
 
     - name: Install Playwright browsers
+      if: steps.secrets-check.outputs.available == 'true'
       run: npx playwright install --with-deps chromium
 
     - name: Check that server is up
+      if: steps.secrets-check.outputs.available == 'true'
       run: curl --retry 2 --retry-delay 5 --retry-connrefused -sSfL http://localhost:5700/api
 
     - name: Run e2e tests
+      if: steps.secrets-check.outputs.available == 'true'
       run: npm run test:e2e
 
     - name: Upload test results
-      if: always()
+      if: always() && steps.secrets-check.outputs.available == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: playwright-report


### PR DESCRIPTION
## Summary

E2E tests require a running gptme-server which needs `ANTHROPIC_API_KEY`. GitHub doesn't expose secrets to workflows triggered by fork PRs for security reasons, causing CI failures for external contributions.

## Changes

- Detects when API keys are unavailable via a secrets check step
- Skips e2e tests with a notice (not warning/error)
- Allows basic checks (build, lint, typecheck, unit tests) to pass for all PRs
- E2E tests still run for pushes to master and internal PRs with secrets access

## Impact

This will allow PRs like #109 and #110 to show green CI for the checks that can run without API access, while clearly indicating that e2e tests were skipped.

Fixes #119

---
-- Thomas 🔧