### PR TITLE
fix: search for actual prev/next visible message in chain

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -11,17 +11,12 @@ import { customRenderer, type CustomRenderer } from '@/utils/markdownRenderer';
 
 interface Props {
   message$: Observable<Message | StreamingMessage>;
-  previousMessage$?: Observable<Message | undefined>;
-  nextMessage$?: Observable<Message | undefined>;
+  log$: Observable<(Message | StreamingMessage)[]>;
+  currentIndex: number;
   conversationId: string;
 }
 
-export const ChatMessage: FC<Props> = ({
-  message$,
-  previousMessage$,
-  nextMessage$,
-  conversationId,
-}) => {
+export const ChatMessage: FC<Props> = ({ message$, log$, currentIndex, conversationId }) => {
   const { connectionConfig } = useApi();
   const { settings } = useSettings();
 
@@ -208,7 +203,7 @@ export const ChatMessage: FC<Props> = ({
     );
   });
 
-  const chainType$ = useMessageChainType(message$, previousMessage$, nextMessage$);
+  const chainType$ = useMessageChainType(message$, log$, currentIndex);
   const messageClasses$ = useObservable(
     () => `
         ${

--- a/src/components/ConversationContent.tsx
+++ b/src/components/ConversationContent.tsx
@@ -185,16 +185,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
               return <div key={`${index}-${message?.timestamp}`} />;
             }
 
-            // Get the previous and next messages for spacing context
-            const previousMessage$ = index > 0 ? conversation$.data.log[index - 1] : undefined;
-            const nextMessage$ = conversation$.data.log[index + 1];
-
             return (
               <ChatMessage
                 key={`${index}-${msg$.timestamp.get()}`}
                 message$={msg$}
-                previousMessage$={previousMessage$}
-                nextMessage$={nextMessage$}
+                log$={conversation$.data.log}
+                currentIndex={index}
                 conversationId={conversationId}
               />
             );

--- a/src/components/__tests__/ChatMessage.test.tsx
+++ b/src/components/__tests__/ChatMessage.test.tsx
@@ -25,36 +25,61 @@ describe('ChatMessage', () => {
   };
 
   it('renders user message', () => {
-    const message$ = observable<Message>({
+    const message: Message = {
       role: 'user',
       content: 'Hello!',
       timestamp: new Date().toISOString(),
-    });
+    };
+    const message$ = observable<Message>(message);
+    const log$ = observable<Message[]>([message]);
 
-    renderWithProviders(<ChatMessage message$={message$} conversationId={testConversationId} />);
+    renderWithProviders(
+      <ChatMessage
+        message$={message$}
+        log$={log$}
+        currentIndex={0}
+        conversationId={testConversationId}
+      />
+    );
     expect(screen.getByText('Hello!')).toBeInTheDocument();
   });
 
   it('renders assistant message', () => {
-    const message$ = observable<Message>({
+    const message: Message = {
       role: 'assistant',
       content: 'Hi there!',
       timestamp: new Date().toISOString(),
-    });
+    };
+    const message$ = observable<Message>(message);
+    const log$ = observable<Message[]>([message]);
 
-    renderWithProviders(<ChatMessage message$={message$} conversationId={testConversationId} />);
+    renderWithProviders(
+      <ChatMessage
+        message$={message$}
+        log$={log$}
+        currentIndex={0}
+        conversationId={testConversationId}
+      />
+    );
     expect(screen.getByText('Hi there!')).toBeInTheDocument();
   });
 
   it('renders system message with monospace font', () => {
-    const message$ = observable<Message>({
+    const message: Message = {
       role: 'system',
       content: 'System message',
       timestamp: new Date().toISOString(),
-    });
+    };
+    const message$ = observable<Message>(message);
+    const log$ = observable<Message[]>([message]);
 
     const { container } = renderWithProviders(
-      <ChatMessage message$={message$} conversationId={testConversationId} />
+      <ChatMessage
+        message$={message$}
+        log$={log$}
+        currentIndex={0}
+        conversationId={testConversationId}
+      />
     );
     const messageElement = container.querySelector('.font-mono');
     expect(messageElement).toBeInTheDocument();


### PR DESCRIPTION
The previous fix (#123) only checked if the immediately adjacent message was hidden. This caused gaps in chains when hidden messages (like lesson inclusions) appeared between visible messages.

For example, in a chain like: user → assistant → tool → lesson (hidden) → assistant

The tool message would see its next message is hidden and assume it was the chain end, causing a visual gap.

Now searches through the log to find the actual prev/next visible message, properly connecting chains across hidden messages.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes message chaining by skipping hidden messages to find actual prev/next visible messages in `ChatMessage`.
> 
>   - **Behavior**:
>     - `ChatMessage` now uses `log$` and `currentIndex` to find actual prev/next visible messages, fixing chain gaps caused by hidden messages.
>     - Updates `useMessageChainType` in `messageUtils.ts` to use `findPrevVisibleMessage` and `findNextVisibleMessage` for accurate chain calculations.
>   - **Props**:
>     - `ChatMessage` props updated: replaces `previousMessage$` and `nextMessage$` with `log$` and `currentIndex`.
>   - **Tests**:
>     - Updates `ChatMessage.test.tsx` to use new `ChatMessage` props `log$` and `currentIndex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme-webui&utm_source=github&utm_medium=referral)<sup> for 7f1f3e949ba32187746461df61312bd18f215199. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->